### PR TITLE
Add Requirement checks command

### DIFF
--- a/bin/manala
+++ b/bin/manala
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Application;
 
 $app = new Application('manala/manala', '1.0.0');
 $app->addCommands([
+    new Command\CheckRequirements(),
     new Command\Setup(),
     new Command\Build(),
 ]);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/console": "~3.1",
         "symfony/filesystem": "~3.1",
         "symfony/process": "~3.1",
-        "symfony/stopwatch": "~3.1"
+        "symfony/stopwatch": "~3.1",
+        "composer/semver": "^1.4"
     },
     "require-dev": {
         "symfony/console": "~3.2@dev",

--- a/src/Command/CheckRequirements.php
+++ b/src/Command/CheckRequirements.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Command;
+
+use Manala\Config\Requirement\Common\RequirementLevel;
+use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
+use Manala\Config\Requirement\Requirement;
+use Manala\Config\Requirement\RequirementChecker;
+use Manala\Config\Requirement\Violation\RequirementViolation;
+use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
+use Manala\Config\Requirement\Violation\RequirementViolationList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Checks if the host's environment meets Manala's requirements (Vagrant, Ansible, etc.).
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class CheckRequirements extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('check:requirements')
+            ->setDescription("Checks if your host's environment meets Manala's requirements (Vagrant, Ansible, etc.)")
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->addFormatter($output);
+
+        $violationList = new RequirementViolationList();
+        $requirementChecker = new RequirementChecker(
+            new HandlerFactoryResolver(),
+            new RequirementViolationLabelBuilder()
+        );
+
+        foreach($this->getRequirements() as $requirement) {
+            $output->writeln('Checking ' . $requirement->getName());
+            $requirementChecker->check($requirement, $violationList);
+        }
+
+        if (count($violationList) > 0) {
+            foreach ($violationList as $violation) {
+                $description = $this->getFormattedViolationDescription($violation);
+                $output->writeln($description);
+            }
+        }
+
+        if (!$violationList->containsRequiredViolations()) {
+            $output->writeln('Congratulations ! Everything seems OK.');
+            if ($violationList->containsRecommendedViolations()) {
+                $output->writeln('Yet, some recommendations have been emitted (see above).');
+            }
+        }
+
+    }
+
+    /**
+     * @return Requirement[]
+     */
+    private function getRequirements()
+    {
+        // @TODO: see https://github.com/composer/semver and adopt it for version requirements
+        return [
+            new Requirement(
+                'vagrant',
+                Requirement::TYPE_BINARY,
+                RequirementLevel::REQUIRED,
+                '1.8.4',
+                '>=',
+                'See https://www.vagrantup.com/downloads.html'
+            ),
+            new Requirement(
+                'landrush',
+                Requirement::TYPE_VAGRANT_PLUGIN,
+                RequirementLevel::REQUIRED,
+                '0.18.0',
+                '>=',
+                'See https://github.com/vagrant-landrush/landrush'
+            ),
+            new Requirement(
+                'ansible',
+                Requirement::TYPE_BINARY,
+                RequirementLevel::RECOMMENDED,
+                '2.0.0',
+                '>=',
+                'Required only if you intend to use the deploy role. See http://docs.ansible.com/ansible/intro_installation.html'
+            ),
+        ];
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function addFormatter(OutputInterface $output)
+    {
+        $errorStyle = new OutputFormatterStyle('red');
+        $output->getFormatter()->setStyle('error', $errorStyle);
+
+        $warningStyle = new OutputFormatterStyle('yellow');
+        $output->getFormatter()->setStyle('warning', $warningStyle);
+    }
+
+    /**
+     * @param RequirementViolation $violation
+     *
+     * @return string Formatted violation description displayed to user.
+     */
+    private function getFormattedViolationDescription(RequirementViolation $violation)
+    {
+        $resultPattern = $violation->isRequired() ? '<error>%s</error>' : '<warning>%s</warning>';
+        $displayedText = $violation->getLabel();
+        $displayedText .= $violation->getHelp() ? ' ' . $violation->getHelp() : '';
+
+        return sprintf($resultPattern, $displayedText);
+    }
+
+}

--- a/src/Command/CheckRequirements.php
+++ b/src/Command/CheckRequirements.php
@@ -80,30 +80,26 @@ class CheckRequirements extends Command
      */
     private function getRequirements()
     {
-        // @TODO: see https://github.com/composer/semver and adopt it for version requirements
         return [
             new Requirement(
                 'vagrant',
                 Requirement::TYPE_BINARY,
                 RequirementLevel::REQUIRED,
-                '1.8.4',
-                '>=',
+                '>= 1.8.0 < 1.8.5 || ^1.8.6', // /!\ Exclude vagrant 1.8.5 (Manala incompatible)
                 'See https://www.vagrantup.com/downloads.html'
             ),
             new Requirement(
                 'landrush',
                 Requirement::TYPE_VAGRANT_PLUGIN,
                 RequirementLevel::REQUIRED,
-                '0.18.0',
-                '>=',
+                '^0.18',
                 'See https://github.com/vagrant-landrush/landrush'
             ),
             new Requirement(
                 'ansible',
                 Requirement::TYPE_BINARY,
                 RequirementLevel::RECOMMENDED,
-                '2.0.0',
-                '>=',
+                '^2.0.0',
                 'Required only if you intend to use the deploy role. See http://docs.ansible.com/ansible/intro_installation.html'
             ),
         ];

--- a/src/Config/Requirement/Common/RequirementLevel.php
+++ b/src/Config/Requirement/Common/RequirementLevel.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Common;
+
+class RequirementLevel
+{
+    const REQUIRED = 1;
+    const RECOMMENDED = 2;
+}

--- a/src/Config/Requirement/Common/RequirementLevel.php
+++ b/src/Config/Requirement/Common/RequirementLevel.php
@@ -11,7 +11,7 @@
 
 namespace Manala\Config\Requirement\Common;
 
-class RequirementLevel
+final class RequirementLevel
 {
     const REQUIRED = 1;
     const RECOMMENDED = 2;

--- a/src/Config/Requirement/Common/RequirementLevelHolderInterface.php
+++ b/src/Config/Requirement/Common/RequirementLevelHolderInterface.php
@@ -12,7 +12,7 @@
 namespace Manala\Config\Requirement\Common;
 
 /**
- * Interface to be implemented by requirement level holders (Eg Requirement, Violation)
+ * Interface to be implemented by requirement level holders (Eg Requirement, Violation).
  */
 interface RequirementLevelHolderInterface
 {

--- a/src/Config/Requirement/Common/RequirementLevelHolderInterface.php
+++ b/src/Config/Requirement/Common/RequirementLevelHolderInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Common;
+
+/**
+ * Interface to be implemented by requirement level holders (Eg Requirement, Violation)
+ */
+interface RequirementLevelHolderInterface
+{
+    /**
+     * @see RequirementLevel
+     *
+     * @return int
+     */
+    public function getLevel();
+
+    /**
+     * Human readable label for requirement level. Eg "Required", "Recommended".
+     *
+     * @return string
+     */
+    public function getLevelLabel();
+
+    /**
+     * Is the requirement mandatory ('Required') or just recommended ?
+     *
+     * @return bool
+     */
+    public function isRequired();
+}

--- a/src/Config/Requirement/Common/RequirementLevelHolderTrait.php
+++ b/src/Config/Requirement/Common/RequirementLevelHolderTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Common;
+
+trait RequirementLevelHolderTrait
+{
+    /**
+     * Is the requirement mandatory ("required") or recommended ?
+     *
+     * @var int
+     */
+    private $level;
+
+    /**
+     * @return int
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLevelLabel()
+    {
+        switch($this->level) {
+            case RequirementLevel::RECOMMENDED:
+                return "Recommended";
+            case RequirementLevel::REQUIRED;
+                return "Required";
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return $this->level === RequirementLevel::REQUIRED;
+    }
+}

--- a/src/Config/Requirement/Common/RequirementLevelHolderTrait.php
+++ b/src/Config/Requirement/Common/RequirementLevelHolderTrait.php
@@ -33,11 +33,11 @@ trait RequirementLevelHolderTrait
      */
     public function getLevelLabel()
     {
-        switch($this->level) {
+        switch ($this->level) {
             case RequirementLevel::RECOMMENDED:
-                return "Recommended";
-            case RequirementLevel::REQUIRED;
-                return "Required";
+                return 'Recommended';
+            case RequirementLevel::REQUIRED:
+                return 'Required';
         }
     }
 

--- a/src/Config/Requirement/Exception/MissingRequirementException.php
+++ b/src/Config/Requirement/Exception/MissingRequirementException.php
@@ -13,5 +13,4 @@ namespace Manala\Config\Requirement\Exception;
 
 class MissingRequirementException extends \Exception
 {
-
 }

--- a/src/Config/Requirement/Exception/MissingRequirementException.php
+++ b/src/Config/Requirement/Exception/MissingRequirementException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Exception;
+
+class MissingRequirementException extends \Exception
+{
+
+}

--- a/src/Config/Requirement/Factory/BinaryHandlerFactory.php
+++ b/src/Config/Requirement/Factory/BinaryHandlerFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Factory;
+
+use Manala\Config\Requirement\Processor\BinaryProcessor;
+use Manala\Config\Requirement\SemVer\BinaryVersionParser;
+
+/**
+ * Factory that instantiates the concrete processor and version parser to handle binary requirements.
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class BinaryHandlerFactory implements HandlerFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return BinaryProcessor
+     */
+    public function getProcessor()
+    {
+        return new BinaryProcessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return BinaryVersionParser
+     */
+    public function getVersionParser()
+    {
+        return new BinaryVersionParser();
+    }
+}

--- a/src/Config/Requirement/Factory/BinaryHandlerFactory.php
+++ b/src/Config/Requirement/Factory/BinaryHandlerFactory.php
@@ -23,8 +23,6 @@ class BinaryHandlerFactory implements HandlerFactoryInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @return BinaryProcessor
      */
     public function getProcessor()
     {
@@ -33,8 +31,6 @@ class BinaryHandlerFactory implements HandlerFactoryInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return BinaryVersionParser
      */
     public function getVersionParser()
     {

--- a/src/Config/Requirement/Factory/HandlerFactoryInterface.php
+++ b/src/Config/Requirement/Factory/HandlerFactoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Factory;
+
+use Manala\Config\Requirement\SemVer\VersionParserInterface;
+use Manala\Config\Requirement\Processor\AbstractProcessor;
+
+/**
+ * Interface for factories that instantiate the proper processor and version parser for a given type of requirement
+ * (eg binary or vagrant plugin).
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+interface HandlerFactoryInterface
+{
+    /**
+     * @return AbstractProcessor
+     */
+    public function getProcessor();
+
+    /**
+     * @return VersionParserInterface
+     */
+    public function getVersionParser();
+}

--- a/src/Config/Requirement/Factory/HandlerFactoryInterface.php
+++ b/src/Config/Requirement/Factory/HandlerFactoryInterface.php
@@ -11,8 +11,8 @@
 
 namespace Manala\Config\Requirement\Factory;
 
-use Manala\Config\Requirement\SemVer\VersionParserInterface;
 use Manala\Config\Requirement\Processor\AbstractProcessor;
+use Manala\Config\Requirement\SemVer\VersionParserInterface;
 
 /**
  * Interface for factories that instantiate the proper processor and version parser for a given type of requirement

--- a/src/Config/Requirement/Factory/HandlerFactoryResolver.php
+++ b/src/Config/Requirement/Factory/HandlerFactoryResolver.php
@@ -12,6 +12,7 @@
 namespace Manala\Config\Requirement\Factory;
 
 use Manala\Config\Requirement\Requirement;
+
 /**
  * This resolver implements the abstract factory pattern: it returns the proper factory that instantiates the concrete
  * handlers (processor and version parser) expected by a requirement (based on its type, eg binary or vagrant plugin).
@@ -29,7 +30,7 @@ class HandlerFactoryResolver
     {
         $type = $requirement->getType();
 
-        switch($type) {
+        switch ($type) {
             case Requirement::TYPE_BINARY:
                 return new BinaryHandlerFactory();
             case Requirement::TYPE_VAGRANT_PLUGIN:

--- a/src/Config/Requirement/Factory/HandlerFactoryResolver.php
+++ b/src/Config/Requirement/Factory/HandlerFactoryResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Factory;
+
+use Manala\Config\Requirement\Requirement;
+/**
+ * This resolver implements the abstract factory pattern: it returns the proper factory that instantiates the concrete
+ * handlers (processor and version parser) expected by a requirement (based on its type, eg binary or vagrant plugin).
+ *
+ * @see https://en.wikipedia.org/wiki/Abstract_factory_pattern
+ */
+class HandlerFactoryResolver
+{
+    /**
+     * @param Requirement $requirement
+     *
+     * @return HandlerFactoryInterface
+     */
+    public function getHandlerFactory(Requirement $requirement)
+    {
+        $type = $requirement->getType();
+
+        switch($type) {
+            case Requirement::TYPE_BINARY:
+                return new BinaryHandlerFactory();
+            case Requirement::TYPE_VAGRANT_PLUGIN:
+                return new VagrantPluginHandlerFactory();
+            default:
+                throw new \InvalidArgumentException(sprintf('No handler factory for type %s', $type));
+        }
+    }
+}

--- a/src/Config/Requirement/Factory/VagrantPluginHandlerFactory.php
+++ b/src/Config/Requirement/Factory/VagrantPluginHandlerFactory.php
@@ -23,8 +23,6 @@ class VagrantPluginHandlerFactory implements HandlerFactoryInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @return VagrantPluginProcessor
      */
     public function getProcessor()
     {
@@ -33,8 +31,6 @@ class VagrantPluginHandlerFactory implements HandlerFactoryInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return VagrantPluginVersionParser
      */
     public function getVersionParser()
     {

--- a/src/Config/Requirement/Factory/VagrantPluginHandlerFactory.php
+++ b/src/Config/Requirement/Factory/VagrantPluginHandlerFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Factory;
+
+use Manala\Config\Requirement\Processor\VagrantPluginProcessor;
+use Manala\Config\Requirement\SemVer\VagrantPluginVersionParser;
+
+/**
+ * Factory that instantiates the concrete processor and version parser to handle vagrant plugin requirements.
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class VagrantPluginHandlerFactory implements HandlerFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return VagrantPluginProcessor
+     */
+    public function getProcessor()
+    {
+        return new VagrantPluginProcessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return VagrantPluginVersionParser
+     */
+    public function getVersionParser()
+    {
+        return new VagrantPluginVersionParser();
+    }
+}

--- a/src/Config/Requirement/Processor/AbstractProcessor.php
+++ b/src/Config/Requirement/Processor/AbstractProcessor.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Processor;
+
+use Manala\Config\Requirement\Exception\MissingRequirementException;
+use Symfony\Component\Process\Process;
+
+abstract class AbstractProcessor
+{
+    /**
+     * Process a required or suggested executable identified by its name (vagrant, ansible, etc.), i.e. run the proper
+     * console command in order to test if it is available on the current host. Each concrete processor is responsible
+     * for running the proper console command (eg `<binary> --version` for an executable, `vagrant plugin list for a`
+     * vagrant plugin, etc.)
+     *
+     * @param string $name The name of the binary (or vagrant plugin or ...) to check
+     *
+     * @throws MissingRequirementException When processed command is unsuccessful
+     *
+     * @return string|null Returns the standard output if tool is available, false otherwise.
+     */
+    public function process($name)
+    {
+        $command = $this->getCommand($name);
+        $process = new Process($command);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new MissingRequirementException();
+        }
+
+        return $process->getOutput();
+    }
+
+    /**
+     * Proper command to run in order to check if an executable is available.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    abstract public function getCommand($name);
+}

--- a/src/Config/Requirement/Processor/AbstractProcessor.php
+++ b/src/Config/Requirement/Processor/AbstractProcessor.php
@@ -20,13 +20,13 @@ abstract class AbstractProcessor
      * Process a required or suggested executable identified by its name (vagrant, ansible, etc.), i.e. run the proper
      * console command in order to test if it is available on the current host. Each concrete processor is responsible
      * for running the proper console command (eg `<binary> --version` for an executable, `vagrant plugin list for a`
-     * vagrant plugin, etc.)
+     * vagrant plugin, etc.).
      *
      * @param string $name The name of the binary (or vagrant plugin or ...) to check
      *
      * @throws MissingRequirementException When processed command is unsuccessful
      *
-     * @return string|null Returns the standard output if tool is available, false otherwise.
+     * @return string The processing command's output if executable is available
      */
     public function process($name)
     {
@@ -35,7 +35,7 @@ abstract class AbstractProcessor
         $process->run();
 
         if (!$process->isSuccessful()) {
-            throw new MissingRequirementException();
+            return $this->handleCommandFailure($process->getErrorOutput());
         }
 
         return $process->getOutput();
@@ -49,4 +49,22 @@ abstract class AbstractProcessor
      * @return string
      */
     abstract public function getCommand($name);
+
+    /**
+     * Override this method in concrete processor implementations if you want to grant a last chance to obtain
+     * information about the executable from the error output.
+     *
+     * Default hereby implementation treats any process failure as a missing executable and therefore throws a
+     * MissingRequirementException.
+     *
+     * @param string $errorOutput
+     *
+     * @throws MissingRequirementException
+     *
+     * @return string
+     */
+    protected function handleCommandFailure($errorOutput)
+    {
+        throw new MissingRequirementException();
+    }
 }

--- a/src/Config/Requirement/Processor/BinaryProcessor.php
+++ b/src/Config/Requirement/Processor/BinaryProcessor.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Processor;
+
+class BinaryProcessor extends AbstractProcessor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getCommand($name)
+    {
+        return sprintf("%s --version", $name);
+    }
+}

--- a/src/Config/Requirement/Processor/BinaryProcessor.php
+++ b/src/Config/Requirement/Processor/BinaryProcessor.php
@@ -18,6 +18,6 @@ class BinaryProcessor extends AbstractProcessor
      */
     public function getCommand($name)
     {
-        return sprintf("%s --version", $name);
+        return sprintf('%s --version', $name);
     }
 }

--- a/src/Config/Requirement/Processor/VagrantPluginProcessor.php
+++ b/src/Config/Requirement/Processor/VagrantPluginProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Processor;
+
+use Manala\Config\Requirement\Exception\MissingRequirementException;
+
+class VagrantPluginProcessor extends AbstractProcessor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process($name)
+    {
+        $output = parent::process($name);
+
+        // If output is empty, it means that the vagrant plugin identified by $name is not installed:
+        if ($output == '') {
+            throw new MissingRequirementException();
+        }
+
+        return $output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCommand($name)
+    {
+        return sprintf('vagrant plugin list | grep %s', $name);
+    }
+}

--- a/src/Config/Requirement/Processor/VagrantPluginProcessor.php
+++ b/src/Config/Requirement/Processor/VagrantPluginProcessor.php
@@ -22,8 +22,8 @@ class VagrantPluginProcessor extends AbstractProcessor
     {
         $output = parent::process($name);
 
-        // If output is empty, it means that the vagrant plugin identified by $name is not installed:
-        if ($output == '') {
+        // If output does not contain '$name', it means that the vagrant plugin is not installed:
+        if (false === strpos($output, $name)) {
             throw new MissingRequirementException();
         }
 
@@ -35,6 +35,6 @@ class VagrantPluginProcessor extends AbstractProcessor
      */
     public function getCommand($name)
     {
-        return sprintf('vagrant plugin list | grep %s', $name);
+        return 'vagrant plugin list';
     }
 }

--- a/src/Config/Requirement/Requirement.php
+++ b/src/Config/Requirement/Requirement.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement;
+
+/**
+ * Class that represents a host's requirement: name of the required binary (eg. Ansible, vagrant, etc.), required version, etc.
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class Requirement implements Common\RequirementLevelHolderInterface
+{
+    use Common\RequirementLevelHolderTrait;
+
+    const TYPE_BINARY = 'binary';
+    const TYPE_VAGRANT_PLUGIN = 'vagrant_plugin';
+
+    /**
+     * Name of the required executable. Eg. Ansible, vagrant, landrush etc.
+     *
+     * @var string
+     */
+    private $name;
+
+    /** @var string */
+    private $requiredVersion;
+
+    /** @var string */
+    private $versionComparator;
+
+    /** @var string */
+    private $type;
+
+    /**
+     * An optional help to display to the user if the binary is missing or if its version is inferior to the
+     * required one. It can be for instance a link to the binary's download page.
+     *
+     * @var string|null
+     */
+    private $help;
+
+    /**
+     * @param string      $name
+     * @param string      $type
+     * @param int         $level
+     * @param string      $requiredVersion
+     * @param string      $versionComparator
+     * @param string|null $help
+     */
+    public function __construct(
+        $name,
+        $type,
+        $level,
+        $requiredVersion = '0.0.0',
+        $versionComparator = '>=',
+        $help = null
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->level = $level;
+        $this->requiredVersion = $requiredVersion;
+        $this->versionComparator = $versionComparator;
+        $this->help = $help;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequiredVersion()
+    {
+        return $this->requiredVersion;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersionComparator()
+    {
+        return $this->versionComparator;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHelp()
+    {
+        return $this->help;
+    }
+}

--- a/src/Config/Requirement/Requirement.php
+++ b/src/Config/Requirement/Requirement.php
@@ -30,18 +30,21 @@ class Requirement implements Common\RequirementLevelHolderInterface
      */
     private $name;
 
-    /** @var string */
-    private $requiredVersion;
-
-    /** @var string */
-    private $versionComparator;
+    /**
+     * Example: '^1.8.2', '~1.8', etc.
+     *
+     * @see https://getcomposer.org/doc/articles/versions.md
+     *
+     * @var string
+     */
+    private $semanticVersion;
 
     /** @var string */
     private $type;
 
     /**
-     * An optional help to display to the user if the binary is missing or if its version is inferior to the
-     * required one. It can be for instance a link to the binary's download page.
+     * An optional help to display to the user if the executable is missing or if its version is inferior to the
+     * required one. It can be for instance a link to the executable's download page.
      *
      * @var string|null
      */
@@ -51,23 +54,20 @@ class Requirement implements Common\RequirementLevelHolderInterface
      * @param string      $name
      * @param string      $type
      * @param int         $level
-     * @param string      $requiredVersion
-     * @param string      $versionComparator
+     * @param string      $semanticVersion
      * @param string|null $help
      */
     public function __construct(
         $name,
         $type,
         $level,
-        $requiredVersion = '0.0.0',
-        $versionComparator = '>=',
+        $semanticVersion,
         $help = null
     ) {
         $this->name = $name;
         $this->type = $type;
         $this->level = $level;
-        $this->requiredVersion = $requiredVersion;
-        $this->versionComparator = $versionComparator;
+        $this->semanticVersion = $semanticVersion;
         $this->help = $help;
     }
 
@@ -90,17 +90,9 @@ class Requirement implements Common\RequirementLevelHolderInterface
     /**
      * @return string
      */
-    public function getRequiredVersion()
+    public function getSemanticVersion()
     {
-        return $this->requiredVersion;
-    }
-
-    /**
-     * @return string
-     */
-    public function getVersionComparator()
-    {
-        return $this->versionComparator;
+        return $this->semanticVersion;
     }
 
     /**

--- a/src/Config/Requirement/RequirementChecker.php
+++ b/src/Config/Requirement/RequirementChecker.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement;
+
+use Manala\Config\Requirement\Exception\MissingRequirementException;
+use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
+use Manala\Config\Requirement\Violation\RequirementViolation;
+use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
+use Manala\Config\Requirement\Violation\RequirementViolationList;
+
+/**
+ * Service that checks if the current host's environment satisfies a requirement.
+ * For example, does the host provide Ansible with the required minimum version ?
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class RequirementChecker
+{
+    /** @var HandlerFactoryResolver */
+    private $handlerFactoryResolver;
+
+    /** @var RequirementViolationLabelBuilder */
+    private $violationLabelBuilder;
+
+    public function __construct(
+        HandlerFactoryResolver $handlerFactoryResolver,
+        RequirementViolationLabelBuilder $violationLabelBuilder
+    ) {
+        $this->handlerFactoryResolver = $handlerFactoryResolver;
+        $this->violationLabelBuilder = $violationLabelBuilder;
+    }
+
+    /**
+     * Check if the host's environment meets the requirement. If not, adds a RequirementViolation to the
+     * violation list.
+     *
+     * @param Requirement              $requirement
+     * @param RequirementViolationList $violationList
+     */
+    public function check(Requirement $requirement, RequirementViolationList $violationList)
+    {
+        $handlerFactory = $this->handlerFactoryResolver->getHandlerFactory($requirement);
+
+        $processor = $handlerFactory->getProcessor();
+        try {
+            $output = $processor->process($requirement->getName());
+        } catch (MissingRequirementException $exception) {
+            $violationList->addViolation($this->createViolation($requirement));
+
+            return;
+        }
+
+        $versionParser = $handlerFactory->getVersionParser();
+        $version = $versionParser->getVersion($requirement->getName(), $output);
+        if (!version_compare($version, $requirement->getRequiredVersion(), $requirement->getVersionComparator())) {
+            $violationList->addViolation($this->createViolation($requirement, $version));
+
+            return;
+        }
+    }
+
+    /**
+     * Create a requirement violation based on the requirement and on the current version of the binary if it exists
+     * (a null current version means that the binary is not installed at all).
+     *
+     * @param Requirement $requirement
+     * @param string|null $currentVersion
+     *
+     * @return RequirementViolation
+     */
+    private function createViolation(Requirement $requirement, $currentVersion = null)
+    {
+        $label = $this->violationLabelBuilder->buildViolationLabel($requirement, $currentVersion);
+
+        return new RequirementViolation($requirement->getName(), $label, $requirement->getLevel(), $requirement->getHelp());
+    }
+}

--- a/src/Config/Requirement/RequirementChecker.php
+++ b/src/Config/Requirement/RequirementChecker.php
@@ -16,6 +16,7 @@ use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
 use Manala\Config\Requirement\Violation\RequirementViolation;
 use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
 use Manala\Config\Requirement\Violation\RequirementViolationList;
+use Composer\Semver\Semver;
 
 /**
  * Service that checks if the current host's environment satisfies a requirement.
@@ -61,7 +62,7 @@ class RequirementChecker
 
         $versionParser = $handlerFactory->getVersionParser();
         $version = $versionParser->getVersion($requirement->getName(), $output);
-        if (!version_compare($version, $requirement->getRequiredVersion(), $requirement->getVersionComparator())) {
+        if (!SemVer::satisfies($version, $requirement->getSemanticVersion())) {
             $violationList->addViolation($this->createViolation($requirement, $version));
 
             return;

--- a/src/Config/Requirement/RequirementChecker.php
+++ b/src/Config/Requirement/RequirementChecker.php
@@ -11,12 +11,12 @@
 
 namespace Manala\Config\Requirement;
 
+use Composer\Semver\Semver;
 use Manala\Config\Requirement\Exception\MissingRequirementException;
 use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
 use Manala\Config\Requirement\Violation\RequirementViolation;
 use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
 use Manala\Config\Requirement\Violation\RequirementViolationList;
-use Composer\Semver\Semver;
 
 /**
  * Service that checks if the current host's environment satisfies a requirement.

--- a/src/Config/Requirement/RequirementRepository.php
+++ b/src/Config/Requirement/RequirementRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement;
+
+use Manala\Config\Requirement\Common\RequirementLevel;
+
+class RequirementRepository
+{
+    /**
+     * @return Requirement[]
+     */
+    public static function getRequirements()
+    {
+        return [
+            new Requirement(
+                'vagrant',
+                Requirement::TYPE_BINARY,
+                RequirementLevel::REQUIRED,
+                '1.8.4 || ^1.8.6', // /!\ Exclude vagrant 1.8.5 (Manala incompatible)
+                'See https://www.vagrantup.com/downloads.html'
+            ),
+            new Requirement(
+                'landrush',
+                Requirement::TYPE_VAGRANT_PLUGIN,
+                RequirementLevel::REQUIRED,
+                '^1.1.2',
+                'See https://github.com/vagrant-landrush/landrush'
+            ),
+            new Requirement(
+                'ansible',
+                Requirement::TYPE_BINARY,
+                RequirementLevel::RECOMMENDED,
+                '^2.1.1',
+                'Required only if you intend to use the deploy role. See http://docs.ansible.com/ansible/intro_installation.html'
+            ),
+        ];
+    }
+}

--- a/src/Config/Requirement/SemVer/BinaryVersionParser.php
+++ b/src/Config/Requirement/SemVer/BinaryVersionParser.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\SemVer;
+
+class BinaryVersionParser implements VersionParserInterface
+{
+    /**
+     * Example: ansible 1.9.4 [...]
+     */
+    const OUTPUT_PATTERN = '/^[a-zA-Z0-9]+\s([0-9]+\.[0-9]+\.[0-9]+)/';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion($name, $consoleOutput)
+    {
+        preg_match(self::OUTPUT_PATTERN, $consoleOutput, $matches);
+        $version = isset($matches[1]) ? $matches[1] : 0;
+
+        return $version;
+    }
+}

--- a/src/Config/Requirement/SemVer/BinaryVersionParser.php
+++ b/src/Config/Requirement/SemVer/BinaryVersionParser.php
@@ -14,7 +14,7 @@ namespace Manala\Config\Requirement\SemVer;
 class BinaryVersionParser implements VersionParserInterface
 {
     /**
-     * Example: ansible 1.9.4 [...]
+     * Example: ansible 1.9.4 [...].
      */
     const OUTPUT_PATTERN = '/^[a-zA-Z0-9]+\s([0-9]+\.[0-9]+\.[0-9]+)/';
 

--- a/src/Config/Requirement/SemVer/VagrantPluginVersionParser.php
+++ b/src/Config/Requirement/SemVer/VagrantPluginVersionParser.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\SemVer;
+
+class VagrantPluginVersionParser implements VersionParserInterface
+{
+    /**
+     * Example: landrush (0.18.0)
+     */
+    const OUTPUT_PATTERN = '/%s\s\(([0-9]+\.[0-9]+\.[0-9]+)\)/';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion($name, $consoleOutput)
+    {
+        $pattern = sprintf(self::OUTPUT_PATTERN, $name);
+        preg_match($pattern, $consoleOutput, $matches);
+        $version = isset($matches[1]) ? $matches[1] : 0;
+
+        return $version;
+    }
+}

--- a/src/Config/Requirement/SemVer/VagrantPluginVersionParser.php
+++ b/src/Config/Requirement/SemVer/VagrantPluginVersionParser.php
@@ -14,7 +14,7 @@ namespace Manala\Config\Requirement\SemVer;
 class VagrantPluginVersionParser implements VersionParserInterface
 {
     /**
-     * Example: landrush (0.18.0)
+     * Example: landrush (0.18.0).
      */
     const OUTPUT_PATTERN = '/%s\s\(([0-9]+\.[0-9]+\.[0-9]+)\)/';
 

--- a/src/Config/Requirement/SemVer/VersionParserInterface.php
+++ b/src/Config/Requirement/SemVer/VersionParserInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\SemVer;
+
+interface VersionParserInterface
+{
+    /**
+     * Get the required executable's version from its command output.
+     *
+     * @param string $name
+     * @param string $consoleOutput
+     *
+     * @return string
+     */
+    public function getVersion($name, $consoleOutput);
+}

--- a/src/Config/Requirement/Violation/RequirementViolation.php
+++ b/src/Config/Requirement/Violation/RequirementViolation.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Violation;
+
+use Manala\Config\Requirement\Common\RequirementLevel;
+use Manala\Config\Requirement\Common\RequirementLevelHolderInterface;
+use Manala\Config\Requirement\Common\RequirementLevelHolderTrait;
+
+/**
+ * Class that represents a requirement violation. It contains the name of the required binary (Ansible, vagrant, etc.),
+ * the violation's label (missing binary or insufficient version), the violation level (required|recommended) and an
+ * optional help.
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class RequirementViolation implements RequirementLevelHolderInterface
+{
+    use RequirementLevelHolderTrait;
+
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $label;
+
+    /** @var string */
+    private $help;
+
+    /**
+     * @param string      $name
+     * @param string      $label
+     * @param int         $level
+     * @param string|null $help
+     */
+    public function __construct($name, $label, $level = RequirementLevel::REQUIRED, $help = null)
+    {
+        $this->name = $name;
+        $this->label = $label;
+        $this->level = $level;
+        $this->help = $help;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHelp()
+    {
+        return $this->help;
+    }
+}

--- a/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
+++ b/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
@@ -25,23 +25,21 @@ class RequirementViolationLabelBuilder
      */
     public function buildViolationLabel(Requirement $requirement, $currentVersion = null)
     {
-        $label = sprintf("[%s] ", strtoupper($requirement->getLevelLabel()));
+        $label = sprintf('[%s] ', strtoupper($requirement->getLevelLabel()));
         $isRequired = $requirement->isRequired();
 
         if ($currentVersion === null) {
             $label .= sprintf(
                 $isRequired ?
-                    "%s is missing. Please install it before proceeding." :
-                    "You should consider installing %s."
-                ,
+                    '%s is missing. Please install it before proceeding.' :
+                    'You should consider installing %s.',
                 $requirement->getName()
             );
         } else {
             $label .= sprintf(
                 $isRequired ?
                     "Your %s version %s doesn't allow you to use this. Required version is %s." :
-                    "Your %s current version is %s. We recommend you to upgrade to version %s"
-                ,
+                    'Your %s current version is %s. We recommend you to upgrade to version %s.',
                 $requirement->getName(),
                 $currentVersion,
                 $requirement->getSemanticVersion()

--- a/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
+++ b/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
@@ -44,7 +44,7 @@ class RequirementViolationLabelBuilder
                 ,
                 $requirement->getName(),
                 $currentVersion,
-                $requirement->getRequiredVersion()
+                $requirement->getSemanticVersion()
             );
         }
 

--- a/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
+++ b/src/Config/Requirement/Violation/RequirementViolationLabelBuilder.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Violation;
+
+use Manala\Config\Requirement\Requirement;
+
+class RequirementViolationLabelBuilder
+{
+    /**
+     * Generates a violation label based on the requirement and current version.
+     *
+     * @param Requirement $requirement
+     * @param string|null $currentVersion Null if expected executable is not installed on host
+     *
+     * @return string
+     */
+    public function buildViolationLabel(Requirement $requirement, $currentVersion = null)
+    {
+        $label = sprintf("[%s] ", strtoupper($requirement->getLevelLabel()));
+        $isRequired = $requirement->isRequired();
+
+        if ($currentVersion === null) {
+            $label .= sprintf(
+                $isRequired ?
+                    "%s is missing. Please install it before proceeding." :
+                    "You should consider installing %s."
+                ,
+                $requirement->getName()
+            );
+        } else {
+            $label .= sprintf(
+                $isRequired ?
+                    "Your %s version %s doesn't allow you to use this. Required version is %s." :
+                    "Your %s current version is %s. We recommend you to upgrade to version %s"
+                ,
+                $requirement->getName(),
+                $currentVersion,
+                $requirement->getRequiredVersion()
+            );
+        }
+
+        return $label;
+    }
+}

--- a/src/Config/Requirement/Violation/RequirementViolationList.php
+++ b/src/Config/Requirement/Violation/RequirementViolationList.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Config\Requirement\Violation;
+
+use Manala\Config\Requirement\Common\RequirementLevel;
+
+/**
+ * Iterable collection of requirement violations.
+ *
+ * @author Xavier Roldo <xavier.roldo@elao.com>
+ */
+class RequirementViolationList implements \Iterator, \ArrayAccess, \Countable
+{
+    /** @var int */
+    private $position;
+
+    /** @var RequirementViolation[] */
+    private $violations = [];
+
+    public function __construct()
+    {
+        $this->rewind();
+        $this->violations = [];
+    }
+
+    public function addViolation(RequirementViolation $violation)
+    {
+        $this->violations[] = $violation;
+    }
+
+    /**
+     * @return RequirementViolation[]
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
+
+    /**
+     * Does the violation list contain at least one violation with the given level ?
+     *
+     * @return bool
+     */
+    private function containsViolations($level)
+    {
+        foreach ($this->violations as $violation) {
+            if ($violation->getLevel() === $level) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function containsRequiredViolations()
+    {
+        return $this->containsViolations(RequirementLevel::REQUIRED);
+    }
+
+    /**
+     * @return bool
+     */
+    public function containsRecommendedViolations()
+    {
+        return $this->containsViolations(RequirementLevel::RECOMMENDED);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequirementViolation
+     */
+    public function current()
+    {
+        return $this->violations[$this->position];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        ++$this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        return $this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        return isset($this->violations[$this->position]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->violations);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->violations[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->violations[$offset]) ? $this->violations[$offset] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param int                  $offset
+     * @param RequirementViolation $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (!$value instanceof RequirementViolation) {
+            throw new \InvalidArgumentException();
+        }
+
+        if ($offset === null) {
+            $this->violations[] = $value;
+
+            return;
+        }
+
+        $this->violations[$offset] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->violations[$offset]);
+    }
+
+
+}

--- a/src/Config/Requirement/Violation/RequirementViolationList.php
+++ b/src/Config/Requirement/Violation/RequirementViolationList.php
@@ -18,23 +18,25 @@ use Manala\Config\Requirement\Common\RequirementLevel;
  *
  * @author Xavier Roldo <xavier.roldo@elao.com>
  */
-class RequirementViolationList implements \Iterator, \ArrayAccess, \Countable
+class RequirementViolationList extends \ArrayObject
 {
-    /** @var int */
-    private $position;
-
-    /** @var RequirementViolation[] */
-    private $violations = [];
-
-    public function __construct()
+    /**
+     * {@inheritdoc}
+     *
+     * @param RequirementViolation[] $violations
+     */
+    public function __construct(array $violations = [])
     {
-        $this->rewind();
-        $this->violations = [];
+        parent::__construct();
+
+        foreach ($violations as $violation) {
+            $this->addViolation($violation);
+        }
     }
 
     public function addViolation(RequirementViolation $violation)
     {
-        $this->violations[] = $violation;
+        $this->append($violation);
     }
 
     /**
@@ -42,7 +44,7 @@ class RequirementViolationList implements \Iterator, \ArrayAccess, \Countable
      */
     public function getViolations()
     {
-        return $this->violations;
+        return $this->getArrayCopy();
     }
 
     /**
@@ -52,7 +54,7 @@ class RequirementViolationList implements \Iterator, \ArrayAccess, \Countable
      */
     private function containsViolations($level)
     {
-        foreach ($this->violations as $violation) {
+        foreach ($this->getViolations() as $violation) {
             if ($violation->getLevel() === $level) {
                 return true;
             }
@@ -76,101 +78,4 @@ class RequirementViolationList implements \Iterator, \ArrayAccess, \Countable
     {
         return $this->containsViolations(RequirementLevel::RECOMMENDED);
     }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequirementViolation
-     */
-    public function current()
-    {
-        return $this->violations[$this->position];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function next()
-    {
-        ++$this->position;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function key()
-    {
-        return $this->position;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function valid()
-    {
-        return isset($this->violations[$this->position]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rewind()
-    {
-        $this->position = 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function count()
-    {
-        return count($this->violations);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->violations[$offset]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetGet($offset)
-    {
-        return isset($this->violations[$offset]) ? $this->violations[$offset] : null;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param int                  $offset
-     * @param RequirementViolation $value
-     */
-    public function offsetSet($offset, $value)
-    {
-        if (!$value instanceof RequirementViolation) {
-            throw new \InvalidArgumentException();
-        }
-
-        if ($offset === null) {
-            $this->violations[] = $value;
-
-            return;
-        }
-
-        $this->violations[$offset] = $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->violations[$offset]);
-    }
-
-
 }

--- a/tests/Config/Requirement/RequirementCheckerTest.php
+++ b/tests/Config/Requirement/RequirementCheckerTest.php
@@ -11,12 +11,12 @@
 
 namespace Manala\Tests\Config\Requirement;
 
+use Manala\Config\Requirement\Common\RequirementLevel;
 use Manala\Config\Requirement\Exception\MissingRequirementException;
 use Manala\Config\Requirement\Factory\HandlerFactoryInterface;
 use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
 use Manala\Config\Requirement\Processor\AbstractProcessor;
 use Manala\Config\Requirement\Requirement;
-use Manala\Config\Requirement\Common\RequirementLevel;
 use Manala\Config\Requirement\RequirementChecker;
 use Manala\Config\Requirement\SemVer\BinaryVersionParser;
 use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
@@ -52,7 +52,7 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
     public function testCheckerShouldCreateAViolationIfRequiredBinaryIsMissing()
     {
         $violationList = new RequirementViolationList();
-        $this->assertEquals(0, count($violationList));
+        $this->assertEmpty($violationList);
 
         $requirement = new Requirement(
             'vagrant',
@@ -64,7 +64,7 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
         $this->processor->process('vagrant')->willThrow(new MissingRequirementException());
 
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(1, count($violationList));
+        $this->assertCount(1, $violationList);
         $this->assertTrue($violationList->containsRequiredViolations());
         $this->assertFalse($violationList->containsRecommendedViolations());
     }
@@ -83,7 +83,7 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
         $this->processor->process('vagrant')->willThrow(new MissingRequirementException());
 
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(1, count($violationList));
+        $this->assertCount(1, $violationList);
         $this->assertFalse($violationList->containsRequiredViolations());
         $this->assertTrue($violationList->containsRecommendedViolations());
     }
@@ -102,7 +102,7 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
         $this->processor->process('vagrant')->willReturn('vagrant 1.7.2');
         $this->handlerFactory->getVersionParser()->willReturn(new BinaryVersionParser());
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(1, count($violationList));
+        $this->assertCount(1, $violationList);
     }
 
     public function testCheckerShouldNotCreateAViolationIfBinaryIsOK()
@@ -119,7 +119,7 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
         $this->processor->process('vagrant')->willReturn('vagrant 1.8.4');
         $this->handlerFactory->getVersionParser()->willReturn(new BinaryVersionParser());
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(0, count($violationList));
+        $this->assertEmpty($violationList);
         $this->assertFalse($violationList->containsRecommendedViolations());
         $this->assertFalse($violationList->containsRequiredViolations());
     }
@@ -139,24 +139,24 @@ class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
         $this->processor->process('vagrant')->willReturn('vagrant 1.8.5');
         $this->handlerFactory->getVersionParser()->willReturn(new BinaryVersionParser());
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(1, count($violationList));
+        $this->assertCount(1, $violationList);
 
         // Version 1.8.4 should pass
         $violationList = new RequirementViolationList();
         $this->processor->process('vagrant')->willReturn('vagrant 1.8.4');
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(0, count($violationList));
+        $this->assertEmpty($violationList);
 
         // Version 1.8.6 should pass
         $violationList = new RequirementViolationList();
         $this->processor->process('vagrant')->willReturn('vagrant 1.8.6');
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(0, count($violationList));
+        $this->assertEmpty($violationList);
 
         // Version 1.9.* should pass
         $violationList = new RequirementViolationList();
         $this->processor->process('vagrant')->willReturn('vagrant 1.9.2');
         $this->requirementChecker->check($requirement, $violationList);
-        $this->assertEquals(0, count($violationList));
+        $this->assertEmpty($violationList);
     }
 }

--- a/tests/Config/Requirement/RequirementCheckerTest.php
+++ b/tests/Config/Requirement/RequirementCheckerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Config\Requirement;
+
+use Manala\Config\Requirement\Exception\MissingRequirementException;
+use Manala\Config\Requirement\Factory\HandlerFactoryInterface;
+use Manala\Config\Requirement\Factory\HandlerFactoryResolver;
+use Manala\Config\Requirement\Processor\AbstractProcessor;
+use Manala\Config\Requirement\Requirement;
+use Manala\Config\Requirement\Common\RequirementLevel;
+use Manala\Config\Requirement\RequirementChecker;
+use Manala\Config\Requirement\SemVer\BinaryVersionParser;
+use Manala\Config\Requirement\Violation\RequirementViolationLabelBuilder;
+use Manala\Config\Requirement\Violation\RequirementViolationList;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class RequirementCheckerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var RequirementChecker */
+    private $requirementChecker;
+
+    /** @var HandlerFactoryInterface|ObjectProphecy */
+    private $handlerFactory;
+
+    /** @var AbstractProcessor|ObjectProphecy */
+    private $processor;
+
+    public function setUp()
+    {
+        $this->handlerFactory = $this->prophesize(HandlerFactoryInterface::class);
+        $this->processor = $this->prophesize(AbstractProcessor::class);
+        $this->handlerFactory->getProcessor()->willReturn($this->processor->reveal());
+        $handlerFactoryResolver = $this->prophesize(HandlerFactoryResolver::class);
+        $handlerFactoryResolver->getHandlerFactory(Argument::any())->willReturn($this->handlerFactory);
+
+        $this->requirementChecker = new RequirementChecker(
+            $handlerFactoryResolver->reveal(),
+            new RequirementViolationLabelBuilder()
+        );
+    }
+
+    public function testCheckerShouldCreateAViolationIfRequiredBinaryIsMissing()
+    {
+        $violationList = new RequirementViolationList();
+        $this->assertEquals(0, count($violationList));
+
+        $requirement = new Requirement(
+            'vagrant',
+            Requirement::TYPE_BINARY,
+            RequirementLevel::REQUIRED
+        );
+
+        $this->processor->process('vagrant')->willThrow(new MissingRequirementException());
+
+        $this->requirementChecker->check($requirement, $violationList);
+        $this->assertEquals(1, count($violationList));
+        $this->assertTrue($violationList->containsRequiredViolations());
+        $this->assertFalse($violationList->containsRecommendedViolations());
+    }
+
+    public function testCheckerShouldCreateAViolationIfRecommendedBinaryIsMissing()
+    {
+        $violationList = new RequirementViolationList();
+
+        $requirement = new Requirement(
+            'vagrant',
+            Requirement::TYPE_BINARY,
+            RequirementLevel::RECOMMENDED
+        );
+
+        $this->processor->process('vagrant')->willThrow(new MissingRequirementException());
+
+        $this->requirementChecker->check($requirement, $violationList);
+        $this->assertEquals(1, count($violationList));
+        $this->assertFalse($violationList->containsRequiredViolations());
+        $this->assertTrue($violationList->containsRecommendedViolations());
+    }
+
+    public function testCheckerShouldCreateAViolationIfRequiredBinaryHasInsufficientVersion()
+    {
+        $violationList = new RequirementViolationList();
+
+        $requirement = new Requirement(
+            'vagrant',
+            Requirement::TYPE_BINARY,
+            RequirementLevel::REQUIRED,
+            '1.8.2'
+        );
+
+        $this->processor->process('vagrant')->willReturn('vagrant 1.7.2');
+        $this->handlerFactory->getVersionParser()->willReturn(new BinaryVersionParser());
+        $this->requirementChecker->check($requirement, $violationList);
+        $this->assertEquals(1, count($violationList));
+    }
+
+    public function testCheckerShouldNotCreateAViolationIfBinaryIsOK()
+    {
+        $violationList = new RequirementViolationList();
+
+        $requirement = new Requirement(
+            'vagrant',
+            Requirement::TYPE_BINARY,
+            RequirementLevel::REQUIRED,
+            '1.8.2'
+        );
+
+        $this->processor->process('vagrant')->willReturn('vagrant 1.8.4');
+        $this->handlerFactory->getVersionParser()->willReturn(new BinaryVersionParser());
+        $this->requirementChecker->check($requirement, $violationList);
+        $this->assertEquals(0, count($violationList));
+        $this->assertFalse($violationList->containsRecommendedViolations());
+        $this->assertFalse($violationList->containsRequiredViolations());
+    }
+}

--- a/tests/Config/Requirement/SemVer/BinaryVersionParserTest.php
+++ b/tests/Config/Requirement/SemVer/BinaryVersionParserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Config\Requirement\SemVer;
+
+use Manala\Config\Requirement\SemVer\BinaryVersionParser;
+
+class BinaryVersionParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $name
+     * @param string $consoleOutput
+     * @param string $expectedVersion
+     *
+     * @dataProvider provideData
+     */
+    public function testBinaryVersionParser($name, $consoleOutput, $expectedVersion)
+    {
+        $parser = new BinaryVersionParser();
+
+        $this->assertEquals($parser->getVersion($name, $consoleOutput), $expectedVersion);
+    }
+
+    public function provideData()
+    {
+        return [
+            [
+                'vagrant',
+                'Vagrant 1.8.4',
+                '1.8.4',
+            ],
+            [
+                'php',
+                "PHP 7.0.8 (cli) (built: Jun 23 2016 16:32:40) ( NTS )
+                 Copyright (c) 1997-2016 The PHP Group
+                 Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies",
+                '7.0.8'
+            ],
+            [
+                'ansible',
+                "ansible 1.9.4
+                configured module search path = None",
+                '1.9.4'
+            ],
+        ];
+    }
+}

--- a/tests/Config/Requirement/SemVer/BinaryVersionParserTest.php
+++ b/tests/Config/Requirement/SemVer/BinaryVersionParserTest.php
@@ -39,16 +39,16 @@ class BinaryVersionParserTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'php',
-                "PHP 7.0.8 (cli) (built: Jun 23 2016 16:32:40) ( NTS )
+                'PHP 7.0.8 (cli) (built: Jun 23 2016 16:32:40) ( NTS )
                  Copyright (c) 1997-2016 The PHP Group
-                 Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies",
-                '7.0.8'
+                 Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies',
+                '7.0.8',
             ],
             [
                 'ansible',
-                "ansible 1.9.4
-                configured module search path = None",
-                '1.9.4'
+                'ansible 1.9.4
+                configured module search path = None',
+                '1.9.4',
             ],
         ];
     }

--- a/tests/Config/Requirement/SemVer/VagrantPluginVersionParserTest.php
+++ b/tests/Config/Requirement/SemVer/VagrantPluginVersionParserTest.php
@@ -34,17 +34,19 @@ class VagrantPluginVersionParserTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 'landrush',
-                'landrush (0.18.0)',
+                'landrush (0.18.0)
+                 vagrant-share (1.1.5, system)',
                 '0.18.0',
             ],
             [
                 'vagrant-plugin',
-                "vagrant-plugin (1.11.15)",
+                'vagrant-share (1.1.5, system)
+                 vagrant-plugin (1.11.15)',
                 '1.11.15',
             ],
             [
                 'anotherPlugin',
-                "anotherPlugin (1.9.14)",
+                'anotherPlugin (1.9.14)',
                 '1.9.14',
             ],
         ];

--- a/tests/Config/Requirement/SemVer/VagrantPluginVersionParserTest.php
+++ b/tests/Config/Requirement/SemVer/VagrantPluginVersionParserTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Config\Requirement\SemVer;
+
+use Manala\Config\Requirement\SemVer\VagrantPluginVersionParser;
+
+class VagrantPluginVersionParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $name
+     * @param string $consoleOutput
+     * @param string $expectedVersion
+     *
+     * @dataProvider provideData
+     */
+    public function testBinaryVersionParser($name, $consoleOutput, $expectedVersion)
+    {
+        $parser = new VagrantPluginVersionParser();
+
+        $this->assertEquals($parser->getVersion($name, $consoleOutput), $expectedVersion);
+    }
+
+    public function provideData()
+    {
+        return [
+            [
+                'landrush',
+                'landrush (0.18.0)',
+                '0.18.0',
+            ],
+            [
+                'vagrant-plugin',
+                "vagrant-plugin (1.11.15)",
+                '1.11.15',
+            ],
+            [
+                'anotherPlugin',
+                "anotherPlugin (1.9.14)",
+                '1.9.14',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**Acceptance criteria:**
- [x] Distinguish between requirements & suggestions (1)
- [x] Introduce checking processors that can be mocked (to make tests environment-agnostic) (2)
- [x] Introduce different checker types : binary checker, vagrant plugin checker, etc. (3)
- [x] Required version: semver-formatted (4)
- [x] Unit tests
- [x] Console output colored according to requirement level (required, recommended, etc.)

(1) vagrant & vagrant plugin landrush are required, ansible is suggested (required to deploy, not to provision VM)

(2) Processing a binary != processing a vagrant plugin

(3) Check vagrant & ansible (binaries) but also check landrush (vagrant plugin) : 
- check that a binary is OK: `<binary> --version`
- check that a vagrant plugin is OK: `vagrant plugin list` and check that the expected plugin is in the list

(4) See https://github.com/composer/semver ; Example: "~1.8"

TODO LATER : 
- Functional test (with venv - virtual environments - https://docs.python.org/3/library/venv.html ?)
