### PR TITLE
Add php-cs-fixer check to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
-    - hhvm
+env:
+    global:
+        - CHECK_PHP_SYNTAX="no"
+        - PATH="$PATH:$HOME/.composer/vendor/bin"
 
 matrix:
     fast_finish: true
+    include:
+        - php: 7.0
+          env: CHECK_PHP_SYNTAX="yes"
+        - php: 5.6
+        - php: hhvm
     allow_failures:
         - php: hhvm
 
@@ -18,6 +23,10 @@ before_install:
     - phpenv config-rm xdebug.ini || true
     - composer selfupdate
 
-install: composer update --prefer-dist --no-interaction --optimize-autoloader
+install:
+    - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then composer global require "friendsofphp/php-cs-fixer"; fi;
+    - composer update --prefer-dist --no-interaction --optimize-autoloader
 
-script: phpunit --exclude-group infra
+script:
+    - phpunit --exclude-group infra
+    - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then php-cs-fixer fix --config-file=.php_cs --dry-run --no-interaction --diff; fi;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -11,8 +11,8 @@
 
 namespace Manala\Command;
 
-use Manala\Handler\Build as BuildHandler;
 use Manala\Exception\HandlerFailureException;
+use Manala\Handler\Build as BuildHandler;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/Setup.php
+++ b/src/Command/Setup.php
@@ -11,8 +11,8 @@
 
 namespace Manala\Command;
 
-use Manala\Env\Dumper;
 use Manala\Env\Config\Variable\AppVendor;
+use Manala\Env\Dumper;
 use Manala\Env\EnvEnum;
 use Manala\Env\EnvFactory;
 use Symfony\Component\Console\Command\Command;

--- a/src/Env/Config/Variable/Variable.php
+++ b/src/Env/Config/Variable/Variable.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Manala\Env\Config\Variable;
 
 /**


### PR DESCRIPTION
(only executed on the PHP 7 build for speed reasons. Also, `hhvm` conflicts with it)

Enabling the cache on travis requires to move the cache file in a dedicated repository we can cache (only folders can be cached on Travis). But IMHO, it's not worth it for so few classes.
