### PR TITLE
Allow configuring dependencies in setup

### DIFF
--- a/src/Env/Config/Ansible.php
+++ b/src/Env/Config/Ansible.php
@@ -44,11 +44,17 @@ class Ansible extends Config
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getTemplate()
     {
-        return $this->getOrigin().'/group_vars/app.yml';
+        return new \SplFileInfo($this->getOrigin().'/group_vars/app.yml');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getPath()
     {
         return 'ansible';

--- a/src/Env/Config/Config.php
+++ b/src/Env/Config/Config.php
@@ -11,6 +11,7 @@
 
 namespace Manala\Env\Config;
 
+use Manala\Env\Config\Variable\Variable;
 use Manala\Env\EnvEnum;
 
 /**
@@ -26,11 +27,17 @@ abstract class Config
     protected $envType;
 
     /**
+     * @var Variable[]
+     */
+    protected $vars;
+
+    /**
      * @param EnvEnum $env
      */
-    public function __construct(EnvEnum $envType)
+    public function __construct(EnvEnum $envType, Variable ...$vars)
     {
         $this->envType = $envType;
+        $this->vars = $vars;
     }
 
     /**
@@ -52,18 +59,15 @@ abstract class Config
      */
     public function getOrigin()
     {
-        return MANALA_DIR.'/src/Resources/'.$this->envType.'/'.$this->getPath();
+        return new \SplFileInfo(MANALA_DIR.'/src/Resources/'.$this->envType.'/'.$this->getPath());
     }
 
     /**
      * Returns the template to render (or its path).
      *
-     * @return \SplFileInfo|string
+     * @return \SplFileInfo|null
      */
-    public function getTemplate()
-    {
-        return $this->getOrigin();
-    }
+    abstract public function getTemplate();
 
     /**
      * Returns the path name of the configuration file or directory.
@@ -73,4 +77,14 @@ abstract class Config
      * @return string
      */
     abstract public function getPath();
+
+    /**
+     * Returns the variables to be used for rendering the template.
+     *
+     * @return array|null
+     */
+    public function getVars()
+    {
+        return $this->vars;
+    }
 }

--- a/src/Env/Config/Make.php
+++ b/src/Env/Config/Make.php
@@ -31,6 +31,6 @@ class Make extends Config
      */
     public function getTemplate()
     {
-        return;
+        return $this->getOrigin();
     }
 }

--- a/src/Env/Config/Vagrant.php
+++ b/src/Env/Config/Vagrant.php
@@ -25,4 +25,12 @@ class Vagrant extends Config
     {
         return 'Vagrantfile';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        return $this->getOrigin();
+    }
 }

--- a/src/Env/Config/Variable/AppVendor.php
+++ b/src/Env/Config/Variable/AppVendor.php
@@ -45,7 +45,7 @@ final class AppVendor implements Variable
     /**
      * {@inheritdoc}
      */
-    public static function validate($value)
+    public static function validate($value = null)
     {
         if (!preg_match('/^([-A-Z0-9])*$/i', $value)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Env/Config/Variable/Dependency/Dependency.php
+++ b/src/Env/Config/Variable/Dependency/Dependency.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Env\Config\Variable\Dependency;
+
+use Manala\Env\Config\Variable\Variable;
+
+/**
+ * Representation of a dependency to be installed during the VM provisioning.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class Dependency implements Variable
+{
+    private $name;
+    private $enabled;
+
+    /**
+     * @param string $name
+     * @param bool   $enabled
+     */
+    public function __construct($name, $enabled)
+    {
+        $this->name = $name;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplaces()
+    {
+        return [
+            $this->getName() => $this->isEnabled(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function validate($value = null)
+    {
+    }
+}

--- a/src/Env/Config/Variable/Dependency/VersionBounded.php
+++ b/src/Env/Config/Variable/Dependency/VersionBounded.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Env\Config\Variable\Dependency;
+
+use Composer\Semver\Semver;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class VersionBounded extends Dependency
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $version
+     */
+    public function __construct($name, $enabled, $version)
+    {
+        parent::__construct($name, $enabled);
+
+        $this->version = $version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplaces()
+    {
+        return [
+            sprintf('%s_version', $this->getName()) => $this->getVersion(),
+        ] + parent::getReplaces();
+    }
+
+    /**
+     * Checks that the required dependency version matches the supported constraint.
+     *
+     * @param string|null $version
+     * @param string|null $constraint
+     */
+    public static function validate($version = null, $constraint = null)
+    {
+        if (false === Semver::satisfies($version, $constraint)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Version "%s" doesn\'t match constraint "%s"',
+                $version,
+                $constraint
+            ));
+        }
+
+        return $version;
+    }
+}

--- a/src/Env/Config/Variable/MakeTarget.php
+++ b/src/Env/Config/Variable/MakeTarget.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Env\Config\Variable;
+
+/**
+ * Manala "app" and "vendor" environment variables.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class MakeTarget implements Variable
+{
+    private $name;
+    private $commands;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name, array $commands)
+    {
+        $this->name = $name;
+        $this->commands = $commands;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplaces()
+    {
+        $replaces = '';
+
+        for ($i = 0; $i < count($this->commands); ++$i) {
+            $command = $this->commands[$i];
+            $replaces .= 0 < $i ? "\n\t$command" : $command;
+        }
+
+        return [
+            sprintf('{{ %s_tasks }}', $this->name) => $replaces,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function validate($value = null)
+    {
+    }
+}

--- a/src/Env/Config/Variable/Variable.php
+++ b/src/Env/Config/Variable/Variable.php
@@ -12,7 +12,8 @@
 namespace Manala\Env\Config\Variable;
 
 /**
- * Must be implemented by classes representing a variable to be rendered.
+ * Must be implemented by classes representing a variable to be replaced when
+ * rendering a given config template.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
@@ -34,5 +35,5 @@ interface Variable
      *
      * @throws \InvalidArgumentException If the value is incorrect
      */
-    public static function validate($value);
+    public static function validate($value = null);
 }

--- a/src/Env/EnvFactory.php
+++ b/src/Env/EnvFactory.php
@@ -14,6 +14,8 @@ namespace Manala\Env;
 use Manala\Env\Config\Ansible;
 use Manala\Env\Config\Make;
 use Manala\Env\Config\Vagrant;
+use Manala\Env\Config\Variable\AppVendor;
+use Manala\Env\Config\Variable\MakeTarget;
 
 /**
  * Provides Env instances.
@@ -27,8 +29,12 @@ class EnvFactory
      *
      * @return Env
      */
-    public static function createEnv(EnvEnum $type)
+    public static function createEnv(EnvEnum $type, AppVendor $appVendor, MakeTarget $postProvisionTask, \Traversable $dependencies)
     {
-        return new Env(new Ansible($type), new Vagrant($type), new Make($type));
+        return new Env(
+            new Ansible($type, ...$dependencies),
+            new Vagrant($type, $appVendor),
+            new Make($type, $postProvisionTask)
+        );
     }
 }

--- a/src/Env/Metadata/MetadataBag.php
+++ b/src/Env/Metadata/MetadataBag.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Env\Metadata;
+
+/**
+ * A metadata bag containing all defaults for a given env type.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class MetadataBag
+{
+    private $elements;
+
+    /**
+     * @param array $elements The raw metadata
+     */
+    public function __construct(array $elements)
+    {
+        $this->elements = $elements;
+    }
+
+    /**
+     * Gets the value of a given metadata option.
+     *
+     * @param string $path The dot path of the option for which to
+     *                     return the value
+     *
+     * @return mixed
+     */
+    public function get($path)
+    {
+        return $this->doGet($this->elements, $path);
+    }
+
+    /**
+     * Checks if a given metadata option exists.
+     *
+     * @param $path The dot path of the option for which to
+     *              check the existance
+     *
+     * @return bool
+     */
+    public function has($path)
+    {
+        return (bool) $this->doGet($this->elements, $path, false);
+    }
+
+    /**
+     * @param array  $elements                    The elements to iterate over
+     * @param string $path                        The path for wich to find the value
+     * @param bool   $throwExceptionOnInvalidPath
+     *
+     * @return mixed
+     *
+     * @throws \LogicException If the given path cannot be found in the given elements and
+     *                         $throwExceptionOnInvalidPath is set to true
+     */
+    private function doGet(array $elements, $path, $throwExceptionOnInvalidPath = true)
+    {
+        $result = $elements;
+        $steps = explode('.', $path);
+
+        foreach ($steps as $step) {
+            if (!array_key_exists($step, $result)) {
+                if (false === $throwExceptionOnInvalidPath) {
+                    return false;
+                }
+
+                throw $this->didYouMean($step, array_keys($result), $path);
+            }
+
+            $result = $result[$step];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Throws a "Did you mean ...?" exception.
+     *
+     * @param string      $search
+     * @param array       $possibleMatches
+     * @param string|null $fullPath
+     *
+     * @return \LogicException
+     */
+    private function didYouMean($search, array $possibleMatches, $fullPath)
+    {
+        $minScore = INF;
+
+        foreach ($possibleMatches as $try) {
+            $distance = levenshtein($search, $try);
+
+            if ($distance < $minScore) {
+                $guess = $try;
+                $minScore = $distance;
+            }
+        }
+
+        $message = sprintf('Unable to find metadata for path "%s".', $fullPath);
+
+        if (isset($guess) && $minScore < 3) {
+            $message .= sprintf(" Did you mean \"%s\"?\n\n", str_replace($search, $guess, $fullPath));
+        } else {
+            $message .= sprintf(
+                ' Possible values: [ %s ]',
+                implode(', ', array_map(function ($match) use ($search, $fullPath) {
+                    return str_replace($search, $match, $fullPath);
+                }, $possibleMatches))
+            );
+        }
+
+        return new \LogicException($message);
+    }
+}

--- a/src/Env/Metadata/MetadataParser.php
+++ b/src/Env/Metadata/MetadataParser.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Env\Metadata;
+
+use Manala\Env\EnvEnum;
+use Symfony\Component\Yaml\Parser;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class MetadataParser
+{
+    const METADATA_PATH = MANALA_DIR.'/src/Resources/%s/manala.yml';
+
+    /**
+     * Parses metadata for a given env type.
+     *
+     * @param EnvEnum $envType
+     *
+     * @return MetadataBag
+     */
+    public static function parse(EnvEnum $envType)
+    {
+        $raw = (new Parser())->parse(file_get_contents(sprintf(self::METADATA_PATH, $envType)));
+
+        return new MetadataBag($raw);
+    }
+}

--- a/src/Handler/Handler.php
+++ b/src/Handler/Handler.php
@@ -13,7 +13,7 @@ namespace Manala\Handler;
 
 /**
  * To be implemented by classes containing logic mostly intended to be used by commands, allowing to
- * reuse its login from everywhere else.
+ * reuse its logic from everywhere else.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */

--- a/src/Resources/symfony/Makefile
+++ b/src/Resources/symfony/Makefile
@@ -60,15 +60,7 @@ provision-php: provision
 
 ## Install application
 install:
-	# Composer
-	composer install --verbose
-	# Doctrine
-	bin/console doctrine:database:create --if-not-exists
-	# Doctrine - Test
-	bin/console doctrine:database:create --if-not-exists --env=test
-	bin/console doctrine:schema:update --force --env=test
-	# Npm
-	if [ -f "package.json" ]; then npm install --no-spin; fi;
+	{{ install_tasks }}
 
 install@test: SYMFONY_ENV = test
 install@test:

--- a/src/Resources/symfony/ansible/group_vars/app.yml
+++ b/src/Resources/symfony/ansible/group_vars/app.yml
@@ -2,10 +2,20 @@
 
 app_options:
 
-  php_version:    '7.0'
-  nodejs_version: '6'
-  mysql:          true
-  mysql_version:  '5.6'
+  php:                   ~
+  php_version:           ~
+  nodejs:                ~
+  nodejs_version:        ~
+  mysql:                 ~
+  mysql_version:         ~
+  mongodb:               ~
+  mongodb_version:       ~
+  postgresql:            ~
+  postgresql_version:    ~
+  elasticsearch:         ~
+  elasticsearch_version: ~
+  redis:                 ~
+  influxdb:              ~
 
 app_patterns:
 

--- a/src/Resources/symfony/manala.yml
+++ b/src/Resources/symfony/manala.yml
@@ -1,0 +1,42 @@
+packages:
+    php:
+        enabled:    true
+        required:   true
+        default:    '7.0'
+        constraint: '5.4|5.5|5.6|7.0'
+    mysql:
+        enabled:    true
+        required:   false
+        default:    '5.6'
+        constraint: '5.6|5.7'
+    postgresql:
+        enabled:    false
+        required:   false
+        default:    '9.5'
+        constraint: '9.4|9.5'
+    mongodb:
+        enabled:    false
+        required:   false
+        default:    '3.2'
+        constraint: '3.0|3.2'
+    elasticsearch:
+        enabled:    false
+        required:   false
+        default:    '1.7'
+        constraint: '1.5|1.6|1.7|2'
+    nodejs:
+        enabled:    false
+        required:   false
+        default:    '6'
+        constraint: '0.10|0.12|4|5|6'
+    redis:
+        required:   false
+        enabled:    false
+    influxdb:
+        required:   false
+        enabled:    false
+
+script:
+    post_provision:
+        - composer install --verbose
+        - bin/console doctrine:database:create --if-not-exists

--- a/tests/Env/Config/MakeTest.php
+++ b/tests/Env/Config/MakeTest.php
@@ -31,6 +31,6 @@ class MakeTest extends BaseTestConfig
     {
         $make = new Make($this->getEnvType());
 
-        $this->assertNull($make->getTemplate());
+        $this->assertInstanceof(\SplFileInfo::class, $make->getTemplate());
     }
 }

--- a/tests/Env/Config/RendererTest.php
+++ b/tests/Env/Config/RendererTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Config;
+
+use Manala\Env\Config\Config;
+use Manala\Env\Config\Renderer;
+use Manala\Env\Config\Variable\Variable;
+
+class RendererTest extends \PHPUnit_Framework_TestCase
+{
+    private static $tempdir;
+
+    public static function setUpBeforeClass()
+    {
+        self::$tempdir = sys_get_temp_dir().'/ManalaRendererTest';
+        @mkdir(self::$tempdir);
+    }
+
+    public function testRender()
+    {
+        file_put_contents(self::$tempdir.'/template', 'foo {{ placeholder }} baz');
+        $var = $this->prophesize(Variable::class);
+        $var->getReplaces()->willReturn(['{{ placeholder }}' => 'bar']);
+        $config = $this->prophesize(Config::class);
+        $config->getVars()->willReturn([$var->reveal()]);
+        $config->getTemplate()->willReturn(new \SplFileInfo(self::$tempdir.'/template'));
+
+        $this->assertSame('foo bar baz', Renderer::render($config->reveal()));
+    }
+
+    public function testRenderYaml()
+    {
+        $template = <<<'YAML'
+key_1: ~
+key_2: ~
+
+YAML;
+        file_put_contents(self::$tempdir.'/template.yml', $template);
+        $var = $this->prophesize(Variable::class);
+        $var->getReplaces()->willReturn(['key_1' => 'foobar', 'key_2' => 'barbaz']);
+        $config = $this->prophesize(Config::class);
+        $config->getVars()->willReturn([$var->reveal()]);
+        $config->getTemplate()->willReturn(new \SplFileInfo(self::$tempdir.'/template.yml'));
+
+        $expected = <<<'YAML'
+key_1: foobar
+key_2: barbaz
+
+YAML;
+        $this->assertSame($expected, Renderer::render($config->reveal()));
+    }
+
+    public function testRenderYamlWithReplacesAtDeepLevel()
+    {
+        $template = <<<'YAML'
+first_level:
+    key_1: foo
+    key_2: bar
+YAML;
+        file_put_contents(self::$tempdir.'/template.yml', $template);
+        $var = $this->prophesize(Variable::class);
+        $var->getReplaces()->willReturn(['key_1' => 'foobar', 'key_2' => 'barbaz']);
+        $config = $this->prophesize(Config::class);
+        $config->getVars()->willReturn([$var->reveal()]);
+        $config->getTemplate()->willReturn(new \SplFileInfo(self::$tempdir.'/template.yml'));
+
+        $expected = <<<'YAML'
+first_level:
+    key_1: foobar
+    key_2: barbaz
+
+YAML;
+
+        $this->assertSame($expected, Renderer::render($config->reveal()));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        @unlink(self::$tempdir.'/template');
+        @unlink(self::$tempdir.'/template.yml');
+        @rmdir(self::$tempdir);
+    }
+}

--- a/tests/Env/Config/Variable/AppVendorTest.php
+++ b/tests/Env/Config/Variable/AppVendorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Env\Config\Variable;
+
+use Manala\Env\Config\Variable\AppVendor;
+
+class AppVendorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetReplaces()
+    {
+        $var = new AppVendor('manala', 'dummy-app');
+
+        $this->assertSame(['{{ vendor }}' => 'manala', '{{ app }}' => 'dummy-app'], $var->getReplaces());
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage This value must contain only alphanumeric characters and hyphens
+     */
+    public function testValidateFailsForNonAlphanumericAndNonHyphenChars()
+    {
+        AppVendor::validate('dummy_app_with_underscores');
+    }
+
+    public function testValidate()
+    {
+        $this->assertSame('dummy-app', AppVendor::validate('dummy-app'));
+    }
+}

--- a/tests/Env/Config/Variable/Dependency/DependencyTest.php
+++ b/tests/Env/Config/Variable/Dependency/DependencyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Env\Config\Variable\Dependency;
+
+use Manala\Env\Config\Variable\Dependency\Dependency;
+
+class DependencyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetReplaces()
+    {
+        $var = new Dependency('brainfuck', true);
+
+        $this->assertSame(['brainfuck' => true], $var->getReplaces());
+    }
+
+    public function testValidateDoesNothing()
+    {
+        $this->assertNull(Dependency::validate('dummyval'));
+    }
+}

--- a/tests/Env/Config/Variable/Dependency/VersionBoundedTest.php
+++ b/tests/Env/Config/Variable/Dependency/VersionBoundedTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Env\Config\Variable\Dependency;
+
+use Manala\Env\Config\Variable\Dependency\VersionBounded;
+
+class VersionBoundedTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetReplaces()
+    {
+        $var = new VersionBounded('brainfuck', true, '2.6');
+
+        $this->assertSame(['brainfuck_version' => '2.6', 'brainfuck' => true], $var->getReplaces());
+    }
+
+    public function testValidate()
+    {
+        $this->assertSame('2.6', VersionBounded::validate('2.6', '2.6|~3.0'));
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Version "2.6" doesn't match constraint "~3.0"
+     */
+    public function testValidateFailsOnIncompatibleVersion()
+    {
+        VersionBounded::validate('2.6', '~3.0');
+    }
+}

--- a/tests/Env/Config/Variable/MakeTargetTest.php
+++ b/tests/Env/Config/Variable/MakeTargetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Env\Config\Variable;
+
+use Manala\Env\Config\Variable\MakeTarget;
+
+class MakeTargetTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetReplaces()
+    {
+        $var = new MakeTarget('dummy', ['cmd1', 'cmd2']);
+
+        $this->assertSame(['{{ dummy_tasks }}' => "cmd1\n\tcmd2"], $var->getReplaces());
+    }
+
+    public function testValidateDoesNothing()
+    {
+        $this->assertNull(MakeTarget::validate('dummyval'));
+    }
+}

--- a/tests/Env/EnvFactoryTest.php
+++ b/tests/Env/EnvFactoryTest.php
@@ -14,6 +14,8 @@ namespace Manala\Tests\Env;
 use Manala\Env\Config\Ansible;
 use Manala\Env\Config\Make;
 use Manala\Env\Config\Vagrant;
+use Manala\Env\Config\Variable\AppVendor;
+use Manala\Env\Config\Variable\MakeTarget;
 use Manala\Env\Env;
 use Manala\Env\EnvEnum;
 use Manala\Env\EnvFactory;
@@ -23,8 +25,10 @@ class EnvFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateEnv()
     {
         $envType = EnvEnum::create(EnvEnum::SYMFONY);
-        $env = EnvFactory::createEnv($envType);
-        $expectedConfigs = [new Ansible($envType), new Vagrant($envType), new Make($envType)];
+        $host = new AppVendor('rch');
+        $postProvisionTask = new MakeTarget('install', ['dummy cmd']);
+        $env = EnvFactory::createEnv($envType, $host, $postProvisionTask, new \ArrayObject());
+        $expectedConfigs = [new Ansible($envType), new Vagrant($envType, $host), new Make($envType, $postProvisionTask)];
 
         $this->assertInstanceOf(Env::class, $env);
         $this->assertEquals($expectedConfigs, $env->getConfigs());

--- a/tests/Env/Metadata/MetadataBagTest.php
+++ b/tests/Env/Metadata/MetadataBagTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Tests\Env\Config\Dependency;
+
+use Manala\Env\Metadata\MetadataBag;
+
+class MetadataBagTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $metadata = new MetadataBag(['foo' => ['bar' => 'baz']]);
+        $this->assertSame('baz', $metadata->get('foo.bar'));
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage Unable to find metadata for path "foo.bab". Did you mean "foo.bar"?
+     */
+    public function testGetUndefinedPath()
+    {
+        $metadata = new MetadataBag(['foo' => ['bar' => 'baz']]);
+        $metadata->get('foo.bab');
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage Unable to find metadata for path "foo.zyo". Possible values: [ foo.bar ]
+     */
+    public function testGetUndefinedPathWithTooMuchDistance()
+    {
+        $metadata = new MetadataBag(['foo' => ['bar' => 'baz']]);
+        $metadata->get('foo.zyo');
+    }
+}

--- a/tests/Functional/BuildTest.php
+++ b/tests/Functional/BuildTest.php
@@ -40,7 +40,7 @@ class BuildTest extends \PHPUnit_Framework_TestCase
             ->run();
 
         (new CommandTester(new Setup()))
-            ->setInputs(['manala', 'dummy'])
+            ->setInputs(['manala', 'dummy', "\n", "\n", "\n", "\n", "\n", "\n"])
             ->execute(['cwd' => $cwd]);
 
         self::$cwd = $cwd;
@@ -66,7 +66,10 @@ class BuildTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
-        (new Process(sprintf('cd %s && vagrant destroy --force && cd %s', self::$cwd, getcwd())))->run();
+        (new Process(sprintf('cd %s && vagrant destroy --force && cd %s', self::$cwd, getcwd())))
+            ->setTimeout(null)
+            ->run();
+
         (new Filesystem())->remove(self::$cwd);
     }
 }

--- a/tests/Functional/SetupTest.php
+++ b/tests/Functional/SetupTest.php
@@ -42,7 +42,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase
     {
         $tester = new CommandTester(new Setup());
         $tester
-            ->setInputs(['manala', 'dummy'])
+            ->setInputs(['manala', 'dummy', "\n", "\n", "\n", "\n", "\n", "\n"])
             ->execute(['cwd' => static::$cwd]);
 
         if (0 !== $tester->getStatusCode()) {
@@ -58,6 +58,21 @@ class SetupTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists(self::$cwd.'/ansible/app.yml');
         $this->assertFileExists(self::$cwd.'/ansible/ansible.yml');
 
+        $appVars = file_get_contents(self::$cwd.'/ansible/group_vars/app.yml');
+        $this->assertContains('php: true', $appVars);
+        $this->assertContains("php_version: '7.0'", $appVars);
+        $this->assertContains('nodejs: false', $appVars);
+        $this->assertContains("nodejs_version: '6'", $appVars);
+        $this->assertContains('mysql: true', $appVars);
+        $this->assertContains("mysql_version: '5.6'", $appVars);
+        $this->assertContains('mongodb: false', $appVars);
+        $this->assertContains("mongodb_version: '3.2'", $appVars);
+        $this->assertContains('postgresql: false', $appVars);
+        $this->assertContains("postgresql_version: '9.5'", $appVars);
+        $this->assertContains('elasticsearch: false', $appVars);
+        $this->assertContains("elasticsearch_version: '1.7'", $appVars);
+        $this->assertContains('redis: false', $appVars);
+        $this->assertContains('influxdb: false', $appVars);
         $this->assertContains(":name        => 'dummy.manala'",  file_get_contents(self::$cwd.'/Vagrantfile'));
     }
 


### PR DESCRIPTION
- [x] In a `packages.yaml` (better name?), define the available packages per env type (only symfony atm) with their version bound and default version
- [x] Ask the user which packages should be installed and (if chosen) in which version
- [x] Dump `ansible/group/vars/app.yml` after merging the `app_options` key with the configured packages 
- [x] Update tests
