### PR TITLE
Fix usage of the HandlingFailureException

### DIFF
--- a/src/Handler/Build.php
+++ b/src/Handler/Build.php
@@ -11,6 +11,7 @@
 
 namespace Manala\Handler;
 
+use Manala\Exception\HandlingFailureException;
 use Manala\Handler\Task\VagrantTask;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
However it does not fix the `BuildTest` for me:

``` sh
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

set -e

mkdir -p ~/.ssh
chmod 0700 ~/.ssh
cat '/tmp/vagrant-insert-pubkey-1475316311' >> ~/.ssh/authorized_keys
chmod 0600 ~/.ssh/authorized_keys

rm -f '/tmp/vagrant-insert-pubkey-1475316311'
```

``` php
Time: 52.81 seconds, Memory: 4.00MB

There was 1 error:

1) Manala\Tests\Functional\BuildTest::testExecute
Manala\Exception\HandlingFailureException: An error occurred while running process "vagrant provision". Use "Manala\Handler\Build::getErrorOutput()" for getting the error output.
```
