### PR TITLE
[Phar] Fix missing bootstrap.php and LICENSE files

### DIFF
--- a/box.json
+++ b/box.json
@@ -35,6 +35,7 @@
       ]
     }
   ],
+  "files": ["bootstrap.php", "LICENSE"],
   "main": "bin/manala",
   "output": "manala.phar",
   "chmod": "0755",


### PR DESCRIPTION
Fixes 

``` sh
PHP Warning:  require_once(phar:///[...]/manala.phar/bin/../bootstrap.php): failed to open stream: phar error: "bootstrap.php" is not a file in phar "[...]/manala.phar" in phar:///[...]/manala.phar/bin/manala on line 12
```

when building and executing the phar.
