### PR TITLE
Add manala diff command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 language: php
 
 env:
@@ -19,6 +20,9 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
+    - sudo add-apt-repository -y ppa:git-core/ppa
+    - sudo apt-get update && sudo apt-get install git-man && sudo apt-get install -y git
+    - git --version
     - phpenv config-rm xdebug.ini || true
 
 install: composer update --prefer-dist --no-interaction --optimize-autoloader

--- a/bin/manala
+++ b/bin/manala
@@ -20,5 +20,6 @@ $app->addCommands([
     new Command\CheckRequirements(),
     new Command\Setup(),
     new Command\Build(),
+    new Command\Diff(),
 ]);
 $app->run();

--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Command;
+
+use Manala\Env\EnvEnum;
+use Manala\Exception\HandlingFailureException;
+use Manala\Handler\Diff as DiffHandler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @author Maxime STEINHAUSSER <maxime.steinhausser@gmail.com>
+ */
+class Diff extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('diff')
+            ->setDescription('Computes the diff between the current project and the Manala templates.')
+            ->addArgument('cwd', InputArgument::OPTIONAL, 'The path of the application', getcwd())
+            ->addOption('env', null, InputOption::VALUE_OPTIONAL, 'One of the supported environment types', 'symfony')
+            ->setHelp(<<<EOTXT
+{$this->getDescription()}
+
+The command output can be redirect to a file in order to create a patch to apply later, or for sharing:
+<info>
+manala diff > my_patch.patch 
+</>
+You can apply the generated patch by executing one of the following command in the project working directory:
+Using <comment>git</>:
+<info>
+$ manala diff | git apply
+$ git apply my_patch.patch
+</>
+Using <comment>patch</>:
+<info>
+$ manala diff | patch -p1
+$ patch -p1 < my_patch.patch
+</>
+As the <comment>git diff</> util, the command exit code is 1 if a diff is detected, 0 otherwise.
+EOTXT
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $cwd = realpath($input->getArgument('cwd'));
+        $envType = EnvEnum::create($input->getOption('env'));
+
+        if (!is_dir($cwd)) {
+            throw new \RuntimeException(sprintf('The working directory "%s" doesn\'t exist.', $cwd));
+        }
+
+        $handler = new DiffHandler($envType, $cwd, $output->isDecorated());
+
+        try {
+            $handler->handle(function ($type, $buffer) use ($output) {
+                $output->write($buffer);
+            });
+        } catch (HandlingFailureException $e) {
+            $io = new SymfonyStyle($input, $output);
+            $io->error(['An error occurred during the process execution:', $handler->getErrorOutput()]);
+
+            return $handler->getExitCode();
+        }
+
+        $errIo = $this->getErrIo($input, $output);
+
+        if (!$handler->hasDiff()) {
+            $errIo->success('No diff found.');
+        }
+
+        return $handler->getExitCode();
+    }
+
+    private function getErrIo(InputInterface $input, OutputInterface $output)
+    {
+        if (!$output instanceof ConsoleOutput) {
+            return new SymfonyStyle($input, new NullOutput());
+        }
+
+        $errIo = new SymfonyStyle($input, $output->getErrorOutput());
+        $errIo->setDecorated(!$input->getOption('no-ansi') || $input->getOption('ansi'));
+
+        return $errIo;
+    }
+}

--- a/src/Exception/InvalidEnvException.php
+++ b/src/Exception/InvalidEnvException.php
@@ -18,9 +18,9 @@ class InvalidEnvException extends \InvalidArgumentException
     public function __construct($invalidEnvName)
     {
         parent::__construct(sprintf(
-            'The env "%s" doesn\'t exist. Possible values: [%s]',
+            'The env "%s" doesn\'t exist. Possible values: %s',
             $invalidEnvName,
-            implode(' ', EnvEnum::getPossibleEnvs())
+            json_encode(EnvEnum::getPossibleEnvs())
         ));
     }
 }

--- a/src/Handler/Diff.php
+++ b/src/Handler/Diff.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Manala package.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Handler;
+
+use Manala\Env\EnvEnum;
+use Manala\Exception\HandlingFailureException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Maxime STEINHAUSSER <maxime.steinhausser@gmail.com>
+ */
+class Diff implements Handler
+{
+    const EXIT_SUCCESS_DIFF = 1;
+    const EXIT_SUCCESS_NO_DIFF = 0;
+
+    /** @var EnvEnum */
+    private $envType;
+
+    /** @var string */
+    private $cwd;
+
+    /** @var bool */
+    private $colorSupport;
+
+    /** @var Filesystem */
+    private $fs;
+
+    /** @var int */
+    private $lastExitCode;
+
+    /** @var string */
+    private $errorOutput;
+
+    /**
+     * @param EnvEnum $envType
+     * @param string  $cwd          The working dir
+     * @param bool    $colorSupport
+     */
+    public function __construct(EnvEnum $envType, $cwd, $colorSupport = true)
+    {
+        $this->envType = $envType;
+        $this->cwd = $cwd;
+        $this->colorSupport = $colorSupport;
+
+        $this->fs = new Filesystem();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(callable $callback = null)
+    {
+        $resourcesPath = $this->copyToTmpLocation($this->getEnvResourcesPath());
+
+        $colorOpt = $this->colorSupport ? '--color' : '--no-color';
+
+        $process = new Process("git diff --diff-filter=d --no-index --patch $colorOpt . $resourcesPath", $this->cwd);
+
+        $process->run(function ($type, $buffer) use ($resourcesPath, $callback) {
+            $buffer = strtr($buffer, [
+                "b$resourcesPath" => 'b',
+                "a$resourcesPath" => 'a',
+                'a/./' => 'a/',
+                'b/./' => 'b/',
+            ]);
+
+            $callback($type, $buffer);
+        });
+
+        $this->lastExitCode = $process->getExitCode();
+
+        if (!$this->isSuccessful()) {
+            $this->errorOutput = $process->getErrorOutput();
+
+            throw new HandlingFailureException(sprintf(
+                'An error occurred while running process "%s". Use "%s::getErrorOutput()" for getting the error output.',
+                $process->getCommandLine(),
+                __CLASS__
+            ));
+        }
+
+        $this->fs->remove($resourcesPath);
+
+        return $this->lastExitCode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExitCode()
+    {
+        return $this->lastExitCode;
+    }
+
+    /**
+     * git-diff is also successful if the exit code is `1`.
+     *
+     * @return bool
+     */
+    public function isSuccessful()
+    {
+        return in_array($this->lastExitCode, [static::EXIT_SUCCESS_NO_DIFF, static::EXIT_SUCCESS_DIFF], true);
+    }
+
+    public function hasDiff()
+    {
+        return $this->lastExitCode === static::EXIT_SUCCESS_DIFF;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorOutput()
+    {
+        return $this->errorOutput;
+    }
+
+    private function copyToTmpLocation($templatePath)
+    {
+        $tmpPath = sys_get_temp_dir().'/Manala/diff';
+
+        if ($this->fs->exists($tmpPath)) {
+            $this->fs->remove($tmpPath);
+        }
+
+        $this->fs->mkdir($tmpPath);
+        $this->fs->mirror($templatePath, $tmpPath);
+
+        return $tmpPath;
+    }
+
+    private function getEnvResourcesPath()
+    {
+        // TODO: Replace by a EnvResourcesLocator
+        return MANALA_DIR.'/src/Resources/'.$this->envType;
+    }
+}

--- a/tests/Env/EnvEnumTest.php
+++ b/tests/Env/EnvEnumTest.php
@@ -25,7 +25,7 @@ class EnvEnumTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        \Manala\Exception\InvalidEnvException
-     * @expectedExceptionMessage The env "dummy" doesn't exist. Possible values: [symfony]
+     * @expectedExceptionMessage The env "dummy" doesn't exist. Possible values: ["symfony"]
      */
     public function testCreateUndefinedEnv()
     {

--- a/tests/fixtures/Command/DiffTest/expected.patch
+++ b/tests/fixtures/Command/DiffTest/expected.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile b/Makefile
+old mode 100644
+new mode 100755
+index 60340e4..bdee98d
+--- a/Makefile
++++ b/Makefile
+@@ -121,5 +121,3 @@ deploy@prod:
+ ##########
+ # Custom #
+ ##########
+- 
+- This line is expected in the patch
+\ No newline at end of file
+diff --git a/Vagrantfile b/Vagrantfile
+old mode 100644
+new mode 100755
+index b93cd8b..14a58a2
+--- a/Vagrantfile
++++ b/Vagrantfile
+@@ -2,7 +2,7 @@
+ # vi: set ft=ruby :
+ 
+ app = {
+-  :name        => 'dummy.manala',
++  :name        => '{{ app }}.{{ vendor }}',
+   :box         => 'manala/app-dev-debian',
+   :box_version => '~> 3.0.0',
+   :box_memory  => 1024
+diff --git a/ansible/deploy.yml b/ansible/deploy.yml
+new file mode 100644
+index 0000000..9ab9e15
+--- /dev/null
++++ b/ansible/deploy.yml
+@@ -0,0 +1,6 @@
++---
++
++- hosts: deploy
++  gather_facts: false
++  roles:
++    - manala.deploy


### PR DESCRIPTION
> https://github.com/manala/manala/pull/37 was improbably closed (missclick) in the exact same time I pushed force the branch. This prevents us from re-opening the previous PR...
### Description

The `manala diff` command generate the diff with the targeted project and manala env templates.

<img width="905" alt="screenshot 2016-10-05 a 00 31 52" src="https://cloud.githubusercontent.com/assets/2211145/19094924/313191b0-8a93-11e6-98d1-a1ce1f973837.PNG">
### Usage:

``` sh
# inside the manalized project with git (repo must be init):
manala diff
manala diff -q | git patch
```

<img width="865" alt="screenshot 2016-10-04 a 22 57 28" src="https://cloud.githubusercontent.com/assets/2211145/19092218/046b114a-8a86-11e6-9b06-61ee8742e6a0.PNG">
#### Full:

``` sh
manala diff tests/fixtures/Command/DiffTest/AcmeProject/ --env=symfony
```

If saved in a file, patch can be applied by using PHPStorm ( ❤️ ) or by executing:

``` sh
 git patch my_patch.patch
```

inside the working directory.
### Known issues

File mode changes cannot be applied by the `patch` util. It means that using the next `manala diff` after applying the changes will still show file mode changes, and calling `patch -p1` again will return:

> patch: ***\* Only garbage was found in the patch input.

That should not be an issue by using `git apply`.
