### PR TITLE
Fix missing dependency when buildign the phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -31,7 +31,8 @@
         "vendor/symfony/filesystem",
         "vendor/symfony/process",
         "vendor/symfony/stopwatch",
-        "vendor/symfony/polyfill-mbstring"
+        "vendor/symfony/polyfill-mbstring",
+        "vendor/nikic/iter"
       ]
     }
   ],


### PR DESCRIPTION
Adding a new dependency in the project means adding it to the `box.json` file, unless the dep is only used for testing purposes.
