### PR TITLE
Fix manala_get_tmp_dir parsing the whole tmp directory

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,6 +15,10 @@ define('UPDATE_FIXTURES', filter_var(getenv('UPDATE_FIXTURES'), FILTER_VALIDATE_
  */
 function manala_get_tmp_dir($prefix = '')
 {
+    if (!is_dir(MANALIZE_TMP_ROOT_DIR)) {
+        @mkdir(MANALIZE_TMP_ROOT_DIR);
+    }
+
     $tmp = @tempnam(MANALIZE_TMP_ROOT_DIR, $prefix);
     unlink($tmp);
     mkdir($tmp, 0777, true);


### PR DESCRIPTION
I just realized that if the first argument passed to `tempnam()` is an unexisting directory, this one quietly use `sys_get_tmp_dir()` instead. So we need to first create the `MANALIZE_TMP_ROOT_DIR` before using `tempnam(MANALIZE_TMP_ROOT_DIR)`, then remove it in `*Test::tearDownAfterClass()`
