### PR TITLE
Update phony targets

### DIFF
--- a/src/Resources/symfony/Makefile
+++ b/src/Resources/symfony/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: help
+.PHONY: build test
 
 ## Colors
 COLOR_RESET   = \033[0m

--- a/tests/fixtures/Command/DiffTest/expected.patch
+++ b/tests/fixtures/Command/DiffTest/expected.patch
@@ -1,7 +1,7 @@
 diff --git a/Makefile b/Makefile
 old mode 100644
 new mode 100755
-index acd1c23..a62e250
+index e122780..a5871ef
 --- a/Makefile
 +++ b/Makefile
 @@ -117,5 +117,3 @@ deploy@prod:


### PR DESCRIPTION
As https://github.com/Elao/symfony-standard/pull/154

It avoid having any issue when a make target is named the same as a directory.
