### PR TITLE
Switch to manala skeleton

### DIFF
--- a/src/Resources/symfony/ansible/app.yml
+++ b/src/Resources/symfony/ansible/app.yml
@@ -5,7 +5,7 @@
     # App
     app: "{{ manala_skeleton_options.app }}"
     # Manala
-    manala_skeleton_name: elao_app_php
+    manala_skeleton_name: manala_app_php
     manala_skeleton_env:  "{{ env }}"
     manala_skeleton_options_hashes:
       - app_options


### PR DESCRIPTION
Ok, sit down, have a cigar, and listen carefuly.

Right now, templates (or call them like you want) are not vendored. I mean "symfony" is just "symfony". As we propose (at least) two skeletons "manala_app_php" and "elao_app_php", we must begin to think about it.
