### PR TITLE
Propose default dependency set before asking for custom

### DIFF
--- a/src/Handler/Setup.php
+++ b/src/Handler/Setup.php
@@ -12,9 +12,12 @@
 namespace Manala\Manalize\Handler;
 
 use Manala\Manalize\Env\Config\Variable\AppName;
+use Manala\Manalize\Env\Config\Variable\Dependency\Dependency;
+use Manala\Manalize\Env\Config\Variable\Dependency\VersionBounded;
 use Manala\Manalize\Env\Dumper;
 use Manala\Manalize\Env\EnvEnum;
 use Manala\Manalize\Env\EnvFactory;
+use Manala\Manalize\Env\Metadata\MetadataBag;
 
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
@@ -47,6 +50,21 @@ class Setup
 
         foreach (Dumper::dump($env, $this->cwd, $this->getDumperFlags()) as $target) {
             $notifier(str_replace($this->cwd.'/', '', $target));
+        }
+    }
+
+    public static function createDefaultDependencySet(MetadataBag $metadata)
+    {
+        foreach ($metadata->get('packages') as $name => $package) {
+            $defaultVersion = $package['default'] ?? null;
+
+            if (null === $defaultVersion) {
+                yield new Dependency($name, $package['enabled']);
+
+                continue;
+            }
+
+            yield new VersionBounded($name, $package['enabled'], $defaultVersion);
         }
     }
 

--- a/tests/Functional/SetupTest.php
+++ b/tests/Functional/SetupTest.php
@@ -67,7 +67,7 @@ class SetupTest extends TestCase
         return [
             // name: project dir name, expected dependencies: default,
             [
-                ["\n", "\n", "\n", "\n", "\n", "\n"],
+                ["\n", "\n"],
                 <<<'RUBY'
   :name        => 'manalized-app',
   :box         => 'manala/app-dev-debian',
@@ -95,7 +95,7 @@ YAML
             ],
             // name: "foo-bar.manala", expected dependencies: php 5.6
             [
-                ['foo-bar.manala', '5.6', "\n", "\n", "\n", "\n", "\n"],
+                ['foo-bar.manala', 'yes', '5.6', "\n", "\n", "\n", "\n", "\n"],
                 <<<'RUBY'
   :name        => 'foo-bar.manala',
   :box         => 'manala/app-dev-debian',
@@ -122,7 +122,7 @@ YAML
             ],
             // name: "foo-bar.manala", expected dependencies: default
             [
-                ['foo-bar.manala', "\n", "\n", "\n", "\n", "\n"],
+                ['foo-bar.manala', "\n"],
                 <<<'RUBY'
   :name        => 'foo-bar.manala',
   :box         => 'manala/app-dev-debian',

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -82,7 +82,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     protected static function manalizeProject($cwd, $appName, EnvEnum $envType, \Iterator $dependencies = null)
     {
         if (null === $dependencies) {
-            $dependencies = self::getDefaultDependenciesForEnv($envType);
+            $dependencies = Setup::createDefaultDependencySet(MetadataParser::parse($envType));
         }
 
         (new Setup($cwd, new AppName($appName), $envType, $dependencies))->handle(function () {


### PR DESCRIPTION
As quickly discussed, this adds a question proposing to keep the default dependency set of the env instead of configuring them one by one.

Output (may be improved):

![](http://image.prntscr.com/image/071b06fc2ff948ce8cb522dd79a3a2ce.png)
