### PR TITLE
Add ScriptHandler for manalizing project using composer events

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Manalize project.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Manalize\Composer;
+
+use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Manala\Manalize\Command\Setup;
+
+/**
+ * Manalize composer script handler.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class ScriptHandler
+{
+    public static function manalizeProject()
+    {
+        self::bootstrap();
+
+        return (new Setup())->run(new ArrayInput(['--env' => 'symfony']), new ConsoleOutput());
+    }
+
+    private static function bootstrap()
+    {
+        if (!defined('MANALIZE_DIR')) {
+            require __DIR__.'/../bootstrap.php';
+        }
+    }
+}


### PR DESCRIPTION
So we can just remove the post-create-project hook from `elao/symfony-standard` and use `Manala\\Manalize\\Composer\\ScriptHandler::manalizeProject` instead.
