### PR TITLE
Linked directories must be removed

### DIFF
--- a/src/Resources/symfony/Makefile
+++ b/src/Resources/symfony/Makefile
@@ -27,9 +27,9 @@ help:
 
 ## Setup environment & Install & Build application
 setup:
-	if [ -d  "./var/cache" ]; then rm -rf ./var/cache && mkdir ./var/cache; fi;
-	if [ -d "./var/logs" ]; then rm -rf ./var/logs && mkdir ./var/logs; fi;
-	if [ -d "./var/sessions" ]; then rm -rf ./var/sessions && mkdir ./var/sessions; fi;
+	if [ -d  "./var/cache" ]; then rm -rf ./var/cache; fi;
+	if [ -d "./var/logs" ]; then rm -rf ./var/logs; fi;
+	if [ -d "./var/sessions" ]; then rm -rf ./var/sessions; fi;
 	vagrant up --no-provision
 	vagrant provision
 	vagrant ssh -- "cd /srv/app && make install && make build"

--- a/tests/fixtures/Command/DiffTest/expected.patch
+++ b/tests/fixtures/Command/DiffTest/expected.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e122780..a5871ef 100644
+index 506d7be..6826e54 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -117,5 +117,3 @@ deploy@prod:


### PR DESCRIPTION
The build fails if the manalized project has one of `var/logs`, `var/cache` or `var/sessions` as directory, even if empty:

> TASK [manala.files : attributes > Link directory - Path link "/srv/app/var/logs"] ***
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "gid": 20, "group": "dialout", "mode": "0755", "msg": "refusing to convert between directory and link for /srv/app/var/logs", "owner": "501", "path": "/srv/app/var/logs", "size": 68, "state": "directory", "uid": 501}
