### PR TITLE
Distinguish Requirement conflicting versions from allowed ones

### DIFF
--- a/src/Command/CheckRequirements.php
+++ b/src/Command/CheckRequirements.php
@@ -55,7 +55,7 @@ class CheckRequirements extends Command
         $io->newLine();
 
         foreach (RequirementRepository::getRequirements() as $requirement) {
-            $io->writeln('Checking '.$requirement->getName());
+            $io->writeln('Checking '.$requirement->getLabel());
             $requirementChecker->check($requirement, $violationList);
         }
 
@@ -66,7 +66,7 @@ class CheckRequirements extends Command
         }
 
         if (!$violationList->containsRequiredViolations()) {
-            $io->success('Congratulations ! Everything seems OK.');
+            $io->success('Congratulations! Everything seems OK.');
             if ($violationList->containsRecommendedViolations()) {
                 $io->note('Yet, some recommendations have been emitted (see above).');
             }
@@ -78,7 +78,7 @@ class CheckRequirements extends Command
         $message = $violation->getLabel();
 
         if ($help = $violation->getHelp()) {
-            $message .= $help;
+            $message .= "\n$help";
         }
 
         return $io->block(

--- a/src/Requirement/Requirement.php
+++ b/src/Requirement/Requirement.php
@@ -23,27 +23,45 @@ class Requirement implements Common\RequirementLevelHolderInterface
     const TYPE_BINARY = 'binary';
     const TYPE_VAGRANT_PLUGIN = 'vagrant_plugin';
 
+    private $label;
     private $name;
     private $semanticVersion;
     private $type;
+    private $conflicts;
     private $help;
 
-    public function __construct(
-        string $name,
-        string $type,
-        int $level,
-        string $semanticVersion,
-        $help = null
-    ) {
+    /**
+     * @param string      $label           The readable name
+     * @param string      $name            The CLI utility name
+     * @param string      $type
+     * @param int         $level           One of 'recommended' and 'required'
+     * @param string      $semanticVersion A semver constraint
+     * @param array       $conflicts       An array of semver constraints corresponding to the conflicting versions of the utility
+     * @param string|null $help            An help to resolve the requirement (i.e. a download link of the good version)
+     */
+    public function __construct(string $label, string $name, string $type, int $level, string $semanticVersion, array $conflicts = [], $help = null)
+    {
+        $this->label = $label;
         $this->name = $name;
         $this->type = $type;
         $this->level = $level;
         $this->semanticVersion = $semanticVersion;
+        $this->conflicts = $conflicts;
         $this->help = $help;
     }
 
     /**
-     * Gets the name of the required package/tool. Eg. Ansible, vagrant, landrush etc.
+     * Gets the label of the required package/tool. Eg. Ansible, Vagrant, VirtualBox, Landrush, etc.
+     *
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Gets the name of the required CLI utility e.g. ansible, vagrant, VboxManage, etc.
      *
      * @return string
      */
@@ -74,6 +92,18 @@ class Requirement implements Common\RequirementLevelHolderInterface
     public function getSemanticVersion(): string
     {
         return $this->semanticVersion;
+    }
+
+    /**
+     * Gets the conflicting versions.
+     *
+     * @see https://getcomposer.org/doc/04-schema.md#conflict
+     *
+     * @return array An array of (semver compatible) versions
+     */
+    public function getConflicts(): array
+    {
+        return $this->conflicts;
     }
 
     /**

--- a/src/Requirement/RequirementChecker.php
+++ b/src/Requirement/RequirementChecker.php
@@ -56,8 +56,17 @@ class RequirementChecker
 
         $versionParser = $handlerFactory->getVersionParser();
         $version = $versionParser->getVersion($requirement->getName(), $output);
+        $isConflictingVersion = false;
 
-        if (!SemVer::satisfies($version, $requirement->getSemanticVersion())) {
+        foreach ($requirement->getConflicts() as $conflictingVersion) {
+            if (SemVer::satisfies($version, $conflictingVersion)) {
+                $isConflictingVersion = true;
+
+                break;
+            }
+        }
+
+        if (!SemVer::satisfies($version, $requirement->getSemanticVersion()) || $isConflictingVersion) {
             $violationList->addViolation($this->createViolation($requirement, $version));
         }
     }

--- a/src/Requirement/RequirementRepository.php
+++ b/src/Requirement/RequirementRepository.php
@@ -22,25 +22,40 @@ class RequirementRepository
     {
         return [
             new Requirement(
+                'Vagrant',
                 'vagrant',
                 Requirement::TYPE_BINARY,
                 RequirementLevel::REQUIRED,
-                '1.8.4 || ^1.8.6', // /!\ Exclude vagrant 1.8.5 (Manala incompatible)
+                '^1.8.4',
+                'Darwin' === php_uname('s') ? ['1.8.5.*', '1.8.6.*', '1.8.7.*'] : ['1.8.5.*', '1.8.6.*'], // /!\ Exclude 1.8.7 for OSX since it is buggy
                 'See https://www.vagrantup.com/downloads.html'
             ),
             new Requirement(
+                'Landrush',
                 'landrush',
                 Requirement::TYPE_VAGRANT_PLUGIN,
                 RequirementLevel::REQUIRED,
-                '^1.1.2',
+                '^1.0.0',
+                [],
                 'See https://github.com/vagrant-landrush/landrush'
             ),
             new Requirement(
+                'Ansible',
                 'ansible',
                 Requirement::TYPE_BINARY,
                 RequirementLevel::RECOMMENDED,
                 '^2.1.1',
+                [],
                 'Required only if you intend to use the deploy role. See http://docs.ansible.com/ansible/intro_installation.html'
+            ),
+            new Requirement(
+                'VirtualBox',
+                'VboxManage',
+                Requirement::TYPE_BINARY,
+                RequirementLevel::RECOMMENDED,
+                '>=5.0.20 <5.0.28',
+                [],
+                'See https://www.virtualbox.org/wiki/Downloads'
             ),
         ];
     }

--- a/src/Requirement/SemVer/BinaryVersionParser.php
+++ b/src/Requirement/SemVer/BinaryVersionParser.php
@@ -14,18 +14,19 @@ namespace Manala\Manalize\Requirement\SemVer;
 class BinaryVersionParser implements VersionParserInterface
 {
     /**
-     * Example: ansible 1.9.4 [...].
+     * Regexp extracting a version from a command output.
+     *
+     * @example 'ansible 1.9.4' gives '1.9.4'
      */
-    const OUTPUT_PATTERN = '/^[a-zA-Z0-9]+\s([0-9]+\.[0-9]+\.[0-9]+)/';
+    const VERSION_PATTERN = '/\d+\.\d+\.\d+/';
 
     /**
      * {@inheritdoc}
      */
     public function getVersion(string $name, string $consoleOutput): string
     {
-        preg_match(self::OUTPUT_PATTERN, $consoleOutput, $matches);
-        $version = isset($matches[1]) ? $matches[1] : 0;
+        preg_match(self::VERSION_PATTERN, $consoleOutput, $matches);
 
-        return $version;
+        return $matches[0] ?? 0;
     }
 }

--- a/src/Requirement/SemVer/VagrantPluginVersionParser.php
+++ b/src/Requirement/SemVer/VagrantPluginVersionParser.php
@@ -14,19 +14,20 @@ namespace Manala\Manalize\Requirement\SemVer;
 class VagrantPluginVersionParser implements VersionParserInterface
 {
     /**
-     * Example: landrush (0.18.0).
+     * Regexp extracting a version of a vagrant plugin from a command output.
+     *
+     * @example 'ansible 1.9.4' gives '1.9.4'
      */
-    const OUTPUT_PATTERN = '/%s\s\(([0-9]+\.[0-9]+\.[0-9]+)\)/';
+    const VERSION_PATTERN = '/%s\s\(([0-9]+\.[0-9]+\.[0-9]+)\)/';
 
     /**
      * {@inheritdoc}
      */
     public function getVersion(string $name, string $consoleOutput): string
     {
-        $pattern = sprintf(self::OUTPUT_PATTERN, $name);
+        $pattern = sprintf(self::VERSION_PATTERN, $name);
         preg_match($pattern, $consoleOutput, $matches);
-        $version = isset($matches[1]) ? $matches[1] : 0;
 
-        return $version;
+        return $matches[1] ?? 0;
     }
 }

--- a/src/Requirement/Violation/RequirementViolationLabelBuilder.php
+++ b/src/Requirement/Violation/RequirementViolationLabelBuilder.php
@@ -26,25 +26,26 @@ class RequirementViolationLabelBuilder
     public function buildViolationLabel(Requirement $requirement, $currentVersion = null): string
     {
         $isRequired = $requirement->isRequired();
+        $label = $requirement->getLabel();
 
-        if ($currentVersion === null) {
-            $label = sprintf(
-                $isRequired ?
-                    '%s is missing. Please install it before proceeding.'.PHP_EOL :
-                    'You should consider installing %s.'.PHP_EOL,
-                $requirement->getName()
-            );
-        } else {
-            $label = sprintf(
-                $isRequired ?
-                    'Your %s version %s doesn\'t allow you to use this. Required version is %s.'.PHP_EOL :
-                    'Your %s current version is %s. We recommend you to upgrade to version %s.'.PHP_EOL,
-                $requirement->getName(),
-                $currentVersion,
-                $requirement->getSemanticVersion()
+        if (null === $currentVersion) {
+            return sprintf(
+                $isRequired ? '%s is missing. Please install it before proceeding.' : 'You should consider installing %s.',
+                $label
             );
         }
 
-        return $label;
+        $constraint = $requirement->getSemanticVersion();
+        $conflicts = $requirement->getConflicts();
+
+        return sprintf(
+            $isRequired ?
+                "Your %s version (%s) doesn't allow you to use this.\nPlease consider changing for a version satisfying constraint %s%s." :
+                'Your %s version is %s. We recommend you to change for a version satifiying constraint %s%s.',
+            $label,
+            $currentVersion,
+            $constraint,
+            $conflicts ? sprintf(' (conflictig versions: %s)', implode(', ', $conflicts)) : ''
+        );
     }
 }


### PR DESCRIPTION
So we can say: `supported: ~1.8.4, conflicts: [1.8.5.*, 1.8.7]` for e.g. Vagrant, instead of unreadable constraints such as `~1.8.4 <1.8.5 || ...`. See https://getcomposer.org/doc/04-schema.md#conflict

After:

![](http://image.prntscr.com/image/0552742057354bc3a9ce7caab586e0d9.png)