### PR TITLE
Fix process error catching in diff

### DIFF
--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -85,20 +85,18 @@ EOTXT
             throw new \RuntimeException(sprintf('The working directory "%s" doesn\'t exist.', $cwd));
         }
 
+        $errIo = $this->getErrIo($input, $output);
         $handler = new DiffHandler($envName, $cwd, $output->isDecorated());
 
         try {
-            $handler->handle(function ($type, $buffer) use ($output) {
-                $output->write($buffer);
+            $handler->handle(function ($diff) use ($output) {
+                $output->write($diff);
             });
         } catch (HandlingFailureException $e) {
-            $io = new SymfonyStyle($input, $output);
-            $io->error(['An error occurred during the process execution:', $handler->getErrorOutput()]);
+            $errIo->error(['An error occurred during the process execution:', $handler->getErrorOutput()]);
 
             return $handler->getExitCode();
         }
-
-        $errIo = $this->getErrIo($input, $output);
 
         if (!$handler->hasDiff()) {
             $errIo->success('No diff found.');


### PR DESCRIPTION
Given `git diff` exits with `1` for both failure (e.g. unknown command) and success revealing some diff, we can't refer to the exit code for differentiating them.

Before:
![before](http://image.prntscr.com/image/81ae571036ff424e9fdaa590d556a867.png)

After:
![after](http://image.prntscr.com/image/989b18fa18f54cc8b5c9f43c2b89e134.png)

ping @ogizanagi 