### PR TITLE
Ask for strategy on already existing file in setup

### DIFF
--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -85,27 +85,25 @@ EOTXT
             throw new \RuntimeException(sprintf('The working directory "%s" doesn\'t exist.', $cwd));
         }
 
-        $errIo = $this->getErrIo($input, $output);
         $handler = new DiffHandler($envName, $cwd, $output->isDecorated());
+        $errorIo = $this->getErrorIo($input, $output);
 
         try {
             $handler->handle(function ($diff) use ($output) {
                 $output->write($diff);
+            }, function () use ($errorIo) {
+                $errorIo->success('No diff found.');
             });
         } catch (HandlingFailureException $e) {
-            $errIo->error(['An error occurred during the process execution:', $handler->getErrorOutput()]);
+            $errorIo->error(['An error occurred during the process execution:', $e->getMessage()]);
 
-            return $handler->getExitCode();
+            return 1;
         }
 
-        if (!$handler->hasDiff()) {
-            $errIo->success('No diff found.');
-        }
-
-        return $handler->getExitCode();
+        return 0;
     }
 
-    private function getErrIo(InputInterface $input, OutputInterface $output)
+    private function getErrorIo(InputInterface $input, OutputInterface $output)
     {
         if (!$output instanceof ConsoleOutput) {
             return new SymfonyStyle($input, new NullOutput());

--- a/src/Env/Dumper.php
+++ b/src/Env/Dumper.php
@@ -11,7 +11,10 @@
 
 namespace Manala\Manalize\Env;
 
+use Manala\Manalize\Env\Config\Config;
 use Manala\Manalize\Env\Config\Renderer;
+use Manala\Manalize\Exception\FailedDumpException;
+use Manala\Manalize\Process\GitDiff;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
@@ -26,57 +29,122 @@ class Dumper
     const DUMP_FILES = 2;
     const DUMP_ALL = 3;
 
+    const DO_REPLACE = 'replace';
+    const DO_PATCH = 'patch';
+    const DO_NOTHING = 'nothing';
+
+    private $workspace;
+    private $patch;
+    private $fs;
+
+    public function __construct(string $workspace)
+    {
+        $this->workspace = $workspace;
+        $this->fs = new Filesystem();
+    }
+
     /**
      * Creates and dumps final config files from stubs.
      *
-     * @param Env    $env     The Env for which to dump the rendered config templates
-     * @param string $workDir The manalized project directory
-     * @param int    $flags
+     * Note: If a file already exists, it can either be erased, a patch can be created for, or
+     * it can be skipped.
+     *
+     * @param Env      $env              The Env for which to dump the rendered config templates
+     * @param int      $flags
+     * @param callable $conflictCallback A callback returning the strategy to be use in case
+     *                                   of existing file
      *
      * @return \Generator The dumped file paths
      */
-    public static function dump(Env $env, string $workDir, int $flags = self::DUMP_ALL): \Generator
+    public function dump(Env $env, int $flags = self::DUMP_ALL, callable $conflictCallback = null): \Generator
     {
         if (self::DUMP_FILES & $flags) {
-            yield from self::dumpFiles($env, $workDir);
+            foreach ($env->getConfigs() as $config) {
+                yield from $this->dumpFiles($config, $conflictCallback);
+            }
+
+            if (null !== $this->patch) {
+                yield $this->dumpPatch();
+            }
         }
 
         if (self::DUMP_METADATA & $flags) {
-            yield self::dumpMetadata($env, $workDir);
+            yield $this->dumpMetadata($env);
         }
     }
 
-    private static function dumpFiles(Env $env, string $workDir): \Generator
+    private function dumpFiles(Config $config, callable $conflictCallback = null): \Generator
     {
-        foreach ($env->getConfigs() as $config) {
-            $baseTarget = "$workDir/{$config->getPath()}";
-            $template = $config->getTemplate();
+        $baseTarget = "$this->workspace/{$config->getPath()}";
+        $template = $config->getTemplate();
 
-            foreach ($config->getFiles() as $file) {
-                $target = str_replace($config->getOrigin(), $baseTarget, $file->getPathName());
-                $dump = $file->getPathname() === (string) $template ? Renderer::render($config) : file_get_contents($file);
-                (new Filesystem())->dumpFile($target, $dump);
+        foreach ($config->getFiles() as $file) {
+            $target = str_replace($config->getOrigin(), $baseTarget, $file->getPathName());
+            $dump = $file->getPathname() === (string) $template ? Renderer::render($config) : file_get_contents($file);
 
-                yield $target;
+            if ($conflictCallback && $this->fs->exists($target) && $dump !== file_get_contents($target)) {
+                $strategy = $conflictCallback($target);
+
+                if (self::DO_NOTHING === $strategy) {
+                    continue;
+                }
+
+                if (self::DO_PATCH === $strategy) {
+                    $this->createPatch($target, $dump);
+
+                    continue;
+                }
             }
+
+            $this->fs->dumpFile($target, $dump);
+
+            yield $target;
         }
     }
 
-    /**
-     * Dumps the metadata into a file.
-     *
-     * @param Env    $env     The Env for which to dump the metadata
-     * @param string $workDir The manalized project directory
-     *
-     * @return string The metadata file path
-     */
-    public static function dumpMetadata(Env $env, string $workDir): string
+    private function dumpMetadata(Env $env): string
     {
         (new Filesystem())->dumpFile(
-            $target = "$workDir/ansible/.manalize.yml",
+            $target = "$this->workspace/ansible/.manalize.yml",
             Yaml::dump((new EnvExporter())->export($env), 4)
         );
 
         return $target;
+    }
+
+    private function dumpPatch(): string
+    {
+        $path = "$this->workspace/manalize.patch";
+
+        if (!$this->patch) {
+            throw new FailedDumpException('Cannot dump an empty patch.');
+        }
+
+        $this->fs->dumpFile($path, $this->patch);
+
+        return $path;
+    }
+
+    private function createPatch(string $path, string $dump)
+    {
+        $tempDir = manala_get_tmp_dir('dump_');
+        $tempDump = str_replace($this->workspace, $tempDir, $path);
+
+        $this->fs->dumpFile($tempDump, $dump);
+
+        $process = new GitDiff(['--no-index', '--patch', '--no-color'], $path, $tempDump);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new FailedDumpException($process->getErrorOutput());
+        }
+
+        $this->fs->remove($tempDir);
+
+        if (null === $this->patch) {
+            $this->patch = '';
+        }
+
+        $this->patch .= strtr($process->getOutput(), ["a$this->workspace" => 'a', "b$tempDir" => 'b']);
     }
 }

--- a/src/Env/EnvName.php
+++ b/src/Env/EnvName.php
@@ -14,9 +14,7 @@ namespace Manala\Manalize\Env;
 use Elao\Enum\ReadableEnum;
 
 /**
- * Manala Env type.
- *
- * @author Robin Chalas <robin.chalas@gmail.com>
+ * @method static EnvName SYMFONY()
  */
 final class EnvName extends ReadableEnum
 {

--- a/src/Exception/FailedDumpException.php
+++ b/src/Exception/FailedDumpException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Manalize project.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Manalize\Exception;
+
+class FailedDumpException extends \RuntimeException
+{
+}

--- a/src/Process/GitDiff.php
+++ b/src/Process/GitDiff.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Manalize project.
+ *
+ * (c) Manala <contact@manala.io>
+ *
+ * For the full copyright and license information, please refer to the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Manala\Manalize\Process;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Process running `git diff`.
+ *
+ * @author Maxime STEINHAUSSER <maxime.steinhausser@gmail.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+final class GitDiff extends Process
+{
+    const EXIT_SUCCESS_DIFF = 1;
+    const EXIT_SUCCESS_NO_DIFF = 0;
+
+    public function __construct(array $options, string $base, string $target, string $cwd = null)
+    {
+        $token = implode(' ', $options);
+
+        parent::__construct("git diff $token $base $target", $cwd, null, null, null);
+    }
+
+    /**
+     * git-diff is also successful if the exit code is `1`.
+     *
+     * @return bool
+     */
+    public function isSuccessful()
+    {
+        if ($this->getErrorOutput()) {
+            return false;
+        }
+
+        return in_array($this->getExitCode(), [static::EXIT_SUCCESS_NO_DIFF, static::EXIT_SUCCESS_DIFF], true);
+    }
+
+    public function hasDiff(): bool
+    {
+        return $this->getExitCode() === static::EXIT_SUCCESS_DIFF;
+    }
+}

--- a/tests/Env/DumperTest.php
+++ b/tests/Env/DumperTest.php
@@ -34,7 +34,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     {
         list($env, $cwd) = $this->createEnv();
 
-        foreach (Dumper::dump($env, $cwd) as $̄);
+        foreach ((new Dumper($cwd))->dump($env) as $̄);
 
         $this->assertFileExists("$cwd/ansible/ansible.yml");
         $this->assertStringEqualsFile("$cwd/ansible/.manalize.yml", Yaml::dump((new EnvExporter())->export($env), 4));
@@ -44,7 +44,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     {
         list($env, $cwd) = $this->createEnv();
 
-        foreach (Dumper::dump($env, $cwd, Dumper::DUMP_METADATA) as $̄);
+        foreach ((new Dumper($cwd))->dump($env, Dumper::DUMP_METADATA) as $̄);
 
         $this->assertFileNotExists("$cwd/ansible/ansible.yml");
         $this->assertFileExists("$cwd/ansible/.manalize.yml");
@@ -54,7 +54,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     {
         list($env, $cwd) = $this->createEnv();
 
-        foreach (Dumper::dump($env, $cwd, Dumper::DUMP_FILES) as $̄);
+        foreach ((new Dumper($cwd))->dump($env, Dumper::DUMP_FILES) as $̄);
 
         $this->assertFileExists("$cwd/ansible/ansible.yml");
         $this->assertFileNotExists("$cwd/ansible/.manalize.yml");

--- a/tests/Functional/DiffTest.php
+++ b/tests/Functional/DiffTest.php
@@ -13,7 +13,6 @@ namespace Manala\Manalize\Tests\Functional;
 
 use Manala\Manalize\Command\Diff;
 use Manala\Manalize\Env\EnvName;
-use Manala\Manalize\Handler\Diff as DiffHandler;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -42,11 +41,11 @@ class DiffTest extends TestCase
         $tester = new CommandTester(new Diff());
         $tester->execute(['cwd' => static::$cwd, '--env' => EnvName::SYMFONY]);
 
-        if (DiffHandler::EXIT_SUCCESS_DIFF !== $tester->getStatusCode()) {
+        if (0 !== $tester->getStatusCode()) {
             echo $tester->getDisplay();
         }
 
-        $this->assertSame(DiffHandler::EXIT_SUCCESS_DIFF, $tester->getStatusCode());
+        $this->assertSame(0, $tester->getStatusCode());
 
         UPDATE_FIXTURES ? file_put_contents(static::EXPECTED_PATCH_FILE, $tester->getDisplay(true)) : null;
 


### PR DESCRIPTION
The `setup` command actually erases any already existing file in the project if it corresponds to one of the environment configuration files, i.e. if the manalized project already has a Makefile, it will just be replaced by the env's one.

Since it is common to have a Makefile in an existing project (or an ansible related file if the project was running under ElaoInfra for instance), I propose to let the user choose between 3 strategies:
- Replace it
- Give me a patch
- Do nothing

Output for an already existing Vagrantfile:

![out](http://image.prntscr.com/image/4701e6a6c92d465492370e6600f3bd37.png)

If the patch strategy is chosen, then the end user can do ~~`git apply Vagrantfile.patch`~~ `git apply manalize.patch`.
Tests will be added depending on feedbacks.

- [x] Add tests

Closes #64 (different approach)