### PR TITLE
Remove per env separation in metadata

### DIFF
--- a/src/Env/EnvExporter.php
+++ b/src/Env/EnvExporter.php
@@ -38,15 +38,14 @@ final class EnvExporter
      */
     public function export(Env $env): array
     {
-        $envName = $env->getName();
-        $metadata = [$envName => []];
+        $metadata = [];
 
         foreach ($env->getConfigs() as $config) {
             $alias = $this->configRegistry->getAliasForClass(get_class($config));
-            $metadata[$envName][$alias] = $this->exportVars($config);
+            $metadata[$alias] = $this->exportVars($config);
         }
 
-        return $metadata;
+        return ['name' => $env->getName(), 'configs' => $metadata];
     }
 
     private function exportVars(Config $config): array

--- a/src/Env/EnvFactory.php
+++ b/src/Env/EnvFactory.php
@@ -36,14 +36,16 @@ class EnvFactory
         );
     }
 
-    public static function createEnvFromMetadata(string $rawName, array $metadata): Env
+    public static function createEnvFromMetadata(array $metadata): Env
     {
         $hydrator = new VariableHydrator();
         $configRegistry = new Registry();
+        $rawName = $metadata['name'];
+        $rawConfigs = $metadata['configs'];
         $name = EnvName::get($rawName);
         $configs = [];
 
-        foreach ($metadata as $configAlias => $perAliasVars) {
+        foreach ($rawConfigs as $configAlias => $perAliasVars) {
             $hydratedVars = [];
             $configClass = $configRegistry->getClassForAlias($configAlias);
 

--- a/src/Handler/Diff.php
+++ b/src/Handler/Diff.php
@@ -89,7 +89,7 @@ class Diff
         $envName = key($metadata);
 
         for (
-            $dump = $dumper->dump(EnvFactory::createEnvFromMetadata($envName, $metadata[$envName]), Dumper::DUMP_FILES);
+            $dump = $dumper->dump(EnvFactory::createEnvFromMetadata($metadata), Dumper::DUMP_FILES);
             $dump->valid();
             $dump->next()
         );

--- a/tests/fixtures/Command/SetupTest/execute_no_update.yml
+++ b/tests/fixtures/Command/SetupTest/execute_no_update.yml
@@ -1,4 +1,5 @@
-symfony:
+name: symfony
+configs:
     vagrant:
         app_name:
             - { value: manalized-app }

--- a/tests/fixtures/Command/SetupTest/metadata_1.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_1.yml
@@ -1,4 +1,5 @@
-symfony:
+name: symfony
+configs:
     vagrant:
         app_name:
             - { value: manalized-app }

--- a/tests/fixtures/Command/SetupTest/metadata_2.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_2.yml
@@ -1,4 +1,5 @@
-symfony:
+name: symfony
+configs:
     vagrant:
         app_name:
             - { value: foo-bar.manala }

--- a/tests/fixtures/Command/SetupTest/metadata_3.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_3.yml
@@ -1,4 +1,5 @@
-symfony:
+name: symfony
+configs:
     vagrant:
         app_name:
             - { value: foo-bar.manala }


### PR DESCRIPTION
First because having several envs in the same directory is not realistic, secondly to ease accessing the vagrant app name by making its path predictable (i.e `configs.vagrant.app_name.value`) so @nervo can easily do its magic.