### PR TITLE
Force vagrant to use virtualbox provider

### DIFF
--- a/src/Resources/symfony/Vagrantfile
+++ b/src/Resources/symfony/Vagrantfile
@@ -12,6 +12,9 @@ Vagrant.require_version '>= 1.8.4'
 
 Vagrant.configure(2) do |config|
 
+  # Force vagrant to use virtualbox provider
+  config.vm.provider "virtualbox"
+  
   # Ssh
   config.ssh.username      = 'app'
   config.ssh.forward_agent = true


### PR DESCRIPTION
If the host has many providers installed like VirtualBox and Parallels and the `VAGRANT_DEFAULT_PROVIDER` env variable is not set to `virtualbox`, `vagrant up` will fail trying to use the wrong provider.

According to [this documentation](https://www.vagrantup.com/docs/providers/basic_usage.html), vagrant will use the first provider it found in a `config.vm.provider` directive of the vagrant file.

>A trick is to use config.vm.provider with no configuration **at the top** of your Vagrantfile to define the order of providers you prefer to support:
>
>```
>Vagrant.configure("2") do |config|
>  # ... other config up here
>
>  # Prefer VMware Fusion before VirtualBox
>  config.vm.provider "vmware_fusion"
>  config.vm.provider "virtualbox"
>end
>```