### PR TITLE
Fix manual build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ $ composer global require manala/manalize
 
 #### Using git:
 ```
-$ git clone git@github.com:manala/manalize
+$ git clone https://github.com/manala/manalize
 $ cd manalize
+$ composer install
 $ make build
 $ mv manalize.phar /usr/local/bin/manalize
 $ chmod a+x /usr/local/bin/manalize

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ composer global require manala/manalize
 
 #### Using git:
 ```
-$ git clone https://github.com/manala/manalize
+$ git clone git@github.com:manala/manalize
 $ cd manalize
 $ composer install
 $ make build


### PR DESCRIPTION
It's needed to run `composer install` (to install the `box`) before calling `make build`.