### PR TITLE
Fix sqlite missing from app_options && enable by default

### DIFF
--- a/src/Resources/common/ansible/group_vars/app_options.yml
+++ b/src/Resources/common/ansible/group_vars/app_options.yml
@@ -17,3 +17,4 @@ app_options:
   redis:                 {# redis_enabled #}
   influxdb:              {# influxdb_enabled #}
   java:                  {# java_enabled #}
+  sqlite:                {# sqlite_enabled #}

--- a/src/Resources/envs/symfony/defaults.yml
+++ b/src/Resources/envs/symfony/defaults.yml
@@ -32,7 +32,7 @@ packages:
         enabled:    false
     sqlite:
         required:   false
-        enabled:    false
+        enabled:    true
     elasticsearch:
         enabled:    false
         required:   false

--- a/tests/fixtures/Command/SetupTest/app_1.yml
+++ b/tests/fixtures/Command/SetupTest/app_1.yml
@@ -19,6 +19,7 @@ app_options:
   redis:                 false
   influxdb:              false
   java:                  false
+  sqlite:                true
 
 app_patterns:
 

--- a/tests/fixtures/Command/SetupTest/app_2.yml
+++ b/tests/fixtures/Command/SetupTest/app_2.yml
@@ -19,6 +19,7 @@ app_options:
   redis:                 false
   influxdb:              false
   java:                  false
+  sqlite:                true
 
 app_patterns:
 

--- a/tests/fixtures/Command/SetupTest/app_3.yml
+++ b/tests/fixtures/Command/SetupTest/app_3.yml
@@ -19,6 +19,7 @@ app_options:
   redis:                 false
   influxdb:              false
   java:                  false
+  sqlite:                true
 
 app_patterns:
 

--- a/tests/fixtures/Command/SetupTest/execute_no_update.yml
+++ b/tests/fixtures/Command/SetupTest/execute_no_update.yml
@@ -17,6 +17,6 @@ configs:
         dependency:
             - { name: redis, enabled: false }
             - { name: influxdb, enabled: false }
-            - { name: sqlite, enabled: false }
+            - { name: sqlite, enabled: true }
             - { name: java, enabled: false }
     make: {  }

--- a/tests/fixtures/Command/SetupTest/metadata_1.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_1.yml
@@ -17,6 +17,6 @@ configs:
         dependency:
             - { name: redis, enabled: false }
             - { name: influxdb, enabled: false }
-            - { name: sqlite, enabled: false }
+            - { name: sqlite, enabled: true }
             - { name: java, enabled: false }
     make: {  }

--- a/tests/fixtures/Command/SetupTest/metadata_2.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_2.yml
@@ -17,6 +17,6 @@ configs:
         dependency:
             - { name: redis, enabled: false }
             - { name: influxdb, enabled: false }
-            - { name: sqlite, enabled: false }
+            - { name: sqlite, enabled: true }
             - { name: java, enabled: false }
     make: {  }

--- a/tests/fixtures/Command/SetupTest/metadata_3.yml
+++ b/tests/fixtures/Command/SetupTest/metadata_3.yml
@@ -17,6 +17,6 @@ configs:
         dependency:
             - { name: redis, enabled: false }
             - { name: influxdb, enabled: false }
-            - { name: sqlite, enabled: false }
+            - { name: sqlite, enabled: true }
             - { name: java, enabled: false }
     make: {  }


### PR DESCRIPTION
Sqlite was missing from the `app_options` template.
Also, I'd suggest to enable it by default, as it's convenient for small apps to start without the VM and have a continuous evolve path when switching to it. But if I'd enable it by default, that's because it's also useful for tests with in memory database, which improves perfs for functional tests: https://github.com/Elao/climalife-k2/pull/970