### PR TITLE
Replace TLD .dev by .vm

### DIFF
--- a/src/Resources/common/Vagrantfile
+++ b/src/Resources/common/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
   # Vm
   config.vm.box           = app[:box]
   config.vm.box_version   = app[:box_version]
-  config.vm.hostname      = app[:name] + '.dev'
+  config.vm.hostname      = app[:name] + '.vm'
   config.vm.network       'private_network', type: 'dhcp'
   config.vm.define        'localhost' do |localhost| end
   config.vm.synced_folder '.', '/srv/app',


### PR DESCRIPTION
Change the tld `.dev` by `.vm`. We'll eventually provide a feature to change it interactively when running `manalize setup`.

Fixes part of https://github.com/manala/manalize/issues/137