### PR TITLE
Update README with prerequisite of PHP 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Manalize is built on the shoulders of the following libs :
 Prerequisites
 -------------
 
-- [PHP](http://php.net) 7.0+
+- [PHP](http://php.net) 7.1+
 - [Vagrant](https://www.vagrantup.com/) 1.8.4+
 - [Vagrant Landrush](https://github.com/vagrant-landrush/landrush) 1.0+
 - [VirtualBox](https://www.virtualbox.org/) 5.0.20+


### PR DESCRIPTION
We check that php 7.1 is installed to use manalize (https://github.com/manala/manalize/pull/143) but the readme still says it is ok with php 7.0+