### PR TITLE
Install "unzip" APT package to prevent problems with Composer

### DIFF
--- a/src/Resources/envs/custom/ansible/group_vars/app.yml
+++ b/src/Resources/envs/custom/ansible/group_vars/app.yml
@@ -4,6 +4,13 @@
 
 app_patterns:
 
+  #######
+  # Apt #
+  #######
+
+  apt_packages:
+    - unzip
+
   ############
   # Timezone #
   ############

--- a/src/Resources/envs/symfony/ansible/group_vars/app.yml
+++ b/src/Resources/envs/symfony/ansible/group_vars/app.yml
@@ -4,6 +4,13 @@
 
 app_patterns:
 
+  #######
+  # Apt #
+  #######
+
+  apt_packages:
+    - unzip
+
   ############
   # Timezone #
   ############


### PR DESCRIPTION
Some weeks ago we encountered [an issue](https://github.com/symfony/panther/issues/54) when installing [symfony/panther](https://github.com/symfony/panther) in our VM because `unzip` was missing.

The execution bit was missing on a binary file packaged in Panther, which makes us not able to run Panther (without `chmod +x` the binary, OFC).

@dunglas found the issue (https://github.com/symfony/panther/issues/54#issuecomment-427972572), it's because package `unzip` wasn't installed, so it's use the buggy PHP Zip extension that is not able to keep the executable bit of binaries...

So I think it would be nice to always have `unzip` installed to prevent some problems.