### PR TITLE
Fix facts gathering on ansible playbook

### DIFF
--- a/src/Resources/envs/custom/ansible/ansible.yml
+++ b/src/Resources/envs/custom/ansible/ansible.yml
@@ -2,7 +2,6 @@
 
 # App
 - hosts: app
-  gather_facts: false
   vars:
     manala_ansible_galaxy_roles:
       - manala.ansible-galaxy
@@ -13,7 +12,6 @@
 
 # Global
 - hosts: all
-  gather_facts: false
   vars:
     manala_ansible_galaxy_roles_path: "{{ playbook_dir }}/roles"
     manala_ansible_galaxy_roles:

--- a/src/Resources/envs/symfony/ansible/ansible.yml
+++ b/src/Resources/envs/symfony/ansible/ansible.yml
@@ -2,7 +2,6 @@
 
 # App
 - hosts: app
-  gather_facts: false
   vars:
     manala_ansible_galaxy_roles:
       - manala.ansible-galaxy
@@ -13,7 +12,6 @@
 
 # Global
 - hosts: all
-  gather_facts: false
   vars:
     manala_ansible_galaxy_roles_path: "{{ playbook_dir }}/roles"
     manala_ansible_galaxy_roles:


### PR DESCRIPTION
Due to some distros limitations (yes, i'm looking at you, debian wheezy) with advanced ssl, `manala.ansible-galaxy` role must now gather facts to decide if it has to disable certificates checking or not.

Fix #153 