### PR TITLE
Update environment variables handling

### DIFF
--- a/src/Resources/envs/custom/ansible/group_vars/app.yml
+++ b/src/Resources/envs/custom/ansible/group_vars/app.yml
@@ -2,6 +2,10 @@
 
 {% include('common/ansible/group_vars/app_options.yml') %}
 
+  #app:
+  #  env_vars:
+  #    FOO: bar
+
 app_patterns:
 
   ############
@@ -9,13 +13,6 @@ app_patterns:
   ############
 
   timezone_default: Etc/UTC
-
-  ###############
-  # Environment #
-  ###############
-
-  # environment_variables:
-  #   - FOO: BAR
 
   #########
   # Files #

--- a/src/Resources/envs/custom/ansible/group_vars/app_local.yml.sample
+++ b/src/Resources/envs/custom/ansible/group_vars/app_local.yml.sample
@@ -1,14 +1,13 @@
 ---
 
+app_local_options:
+
+  #app:
+  #  env_vars:
+  #    XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
+  #    PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
+
 app_local_patterns:
-
-  ###############
-  # Environment #
-  ###############
-
-  #environment_variables:
-  #  - XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
-  #  - PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
 
   #######
   # Apt #

--- a/src/Resources/envs/symfony/ansible/group_vars/app.yml
+++ b/src/Resources/envs/symfony/ansible/group_vars/app.yml
@@ -2,6 +2,10 @@
 
 {% include('common/ansible/group_vars/app_options.yml') %}
 
+  #app:
+  #  env_vars:
+  #    FOO: bar
+
 app_patterns:
 
   ############
@@ -9,13 +13,6 @@ app_patterns:
   ############
 
   timezone_default: Etc/UTC
-
-  ###############
-  # Environment #
-  ###############
-
-  # environment_variables:
-  #   - FOO: BAR
 
   #########
   # Files #

--- a/src/Resources/envs/symfony/ansible/group_vars/app_local.yml.sample
+++ b/src/Resources/envs/symfony/ansible/group_vars/app_local.yml.sample
@@ -1,14 +1,13 @@
 ---
 
+app_local_options:
+
+  #app:
+  #  env_vars:
+  #    XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
+  #    PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
+
 app_local_patterns:
-
-  ###############
-  # Environment #
-  ###############
-
-  #environment_variables:
-  #  - XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
-  #  - PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
 
   #######
   # Apt #

--- a/tests/fixtures/Command/SetupTest/app_1.yml
+++ b/tests/fixtures/Command/SetupTest/app_1.yml
@@ -21,6 +21,10 @@ app_options:
   java:                  false
   sqlite:                true
 
+  #app:
+  #  env_vars:
+  #    FOO: bar
+
 app_patterns:
 
   ############
@@ -28,13 +32,6 @@ app_patterns:
   ############
 
   timezone_default: Etc/UTC
-
-  ###############
-  # Environment #
-  ###############
-
-  # environment_variables:
-  #   - FOO: BAR
 
   #########
   # Files #

--- a/tests/fixtures/Command/SetupTest/app_2.yml
+++ b/tests/fixtures/Command/SetupTest/app_2.yml
@@ -21,6 +21,10 @@ app_options:
   java:                  false
   sqlite:                true
 
+  #app:
+  #  env_vars:
+  #    FOO: bar
+
 app_patterns:
 
   ############
@@ -28,13 +32,6 @@ app_patterns:
   ############
 
   timezone_default: Etc/UTC
-
-  ###############
-  # Environment #
-  ###############
-
-  # environment_variables:
-  #   - FOO: BAR
 
   #########
   # Files #

--- a/tests/fixtures/Command/SetupTest/app_3.yml
+++ b/tests/fixtures/Command/SetupTest/app_3.yml
@@ -21,6 +21,10 @@ app_options:
   java:                  false
   sqlite:                true
 
+  #app:
+  #  env_vars:
+  #    FOO: bar
+
 app_patterns:
 
   ############
@@ -28,13 +32,6 @@ app_patterns:
   ############
 
   timezone_default: Etc/UTC
-
-  ###############
-  # Environment #
-  ###############
-
-  # environment_variables:
-  #   - FOO: BAR
 
   #########
   # Files #


### PR DESCRIPTION
Using `environment_variables` is deprecated, in favor of `app.env_vars` which handle properly environment variables both in zsh *and* php fpm

See: https://github.com/manala/ansible-role-skeleton/commit/9afb906b6da4d8a3ad2d285acea72699ddc5eeaa