### PR TITLE
Remove php zip extension

### DIFF
--- a/src/Resources/envs/custom/ansible/group_vars/app.yml
+++ b/src/Resources/envs/custom/ansible/group_vars/app.yml
@@ -55,8 +55,6 @@ app_patterns:
     - curl
     - mbstring
     - xml
-    # Composer
-    - zip
     # App
 
   php_configs:

--- a/src/Resources/envs/symfony/ansible/group_vars/app.yml
+++ b/src/Resources/envs/symfony/ansible/group_vars/app.yml
@@ -52,8 +52,6 @@ app_patterns:
     - curl
     - mbstring
     - xml
-    # Composer
-    - zip
     # App
 
   php_configs:

--- a/tests/fixtures/Command/SetupTest/app_1.yml
+++ b/tests/fixtures/Command/SetupTest/app_1.yml
@@ -71,8 +71,6 @@ app_patterns:
     - curl
     - mbstring
     - xml
-    # Composer
-    - zip
     # App
 
   php_configs:

--- a/tests/fixtures/Command/SetupTest/app_2.yml
+++ b/tests/fixtures/Command/SetupTest/app_2.yml
@@ -71,8 +71,6 @@ app_patterns:
     - curl
     - mbstring
     - xml
-    # Composer
-    - zip
     # App
 
   php_configs:

--- a/tests/fixtures/Command/SetupTest/app_3.yml
+++ b/tests/fixtures/Command/SetupTest/app_3.yml
@@ -71,8 +71,6 @@ app_patterns:
     - curl
     - mbstring
     - xml
-    # Composer
-    - zip
     # App
 
   php_configs:


### PR DESCRIPTION
'was needed by default for composer only. Composer now prefers using system unzip binary, which is now installed by related role.

See: https://github.com/manala/ansible-role-composer/commit/ab84be2a24caa4797578853a887c258fa7b349ea