### PR TITLE
feat(vagrantfile): import `~/.gitignore_global` too

### DIFF
--- a/src/Resources/common/Vagrantfile
+++ b/src/Resources/common/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
   end
 
   # Vm - Provision - Dotfiles
-  for dotfile in ['.ssh/config', '.gitconfig', '.gitignore', '.composer/auth.json']
+  for dotfile in ['.ssh/config', '.gitconfig', '.gitignore', '.gitignore_global', '.composer/auth.json']
     if File.exists?(File.join(Dir.home, dotfile)) then
       config.vm.provision dotfile, type: 'file', run: 'always' do |file|
         file.source      = '~/' + dotfile


### PR DESCRIPTION
I'm sure that many people used [this page](https://help.github.com/en/articles/ignoring-files#create-a-global-gitignore) to create a global `.gitignore` that contains something like this:
```
.idea/
*.iml
.vscode/
```

With this modification, we will prevent mistakes when running `git add .` in the VM:
![Sélection_393](https://user-images.githubusercontent.com/2103975/54271221-663ecc00-4581-11e9-9812-4a33afc0f1a9.png)

Thanks