### PR TITLE
chore: fix Twig deprecations in tests

### DIFF
--- a/src/Env/Config/Renderer.php
+++ b/src/Env/Config/Renderer.php
@@ -13,6 +13,7 @@ namespace Manala\Manalize\Env\Config;
 
 use Manala\Manalize\Twig\FilesystemLoader;
 use Manala\Manalize\Twig\Lexer;
+use Twig\Environment;
 
 /**
  * Config' template renderer.
@@ -23,10 +24,10 @@ class Renderer
 {
     private $twig;
 
-    public function __construct(\Twig_Environment $twig = null)
+    public function __construct(Environment $twig = null)
     {
         if (null === $twig) {
-            $twig = new \Twig_Environment(new FilesystemLoader(), [
+            $twig = new Environment(new FilesystemLoader(), [
                 'debug' => $debug = '' === \Phar::running(),
                 'cache' => $debug ? MANALIZE_DIR.'/var/cache' : manala_get_tmp_dir(),
             ]);

--- a/src/Twig/FilesystemLoader.php
+++ b/src/Twig/FilesystemLoader.php
@@ -11,12 +11,14 @@
 
 namespace Manala\Manalize\Twig;
 
+use Twig\Loader\FilesystemLoader as BaseFilesystemLoader;
+
 /**
  * Loads templates through absolute paths in addition of relative ones.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class FilesystemLoader extends \Twig_Loader_Filesystem
+final class FilesystemLoader extends BaseFilesystemLoader
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Lexer.php
+++ b/src/Twig/Lexer.php
@@ -11,14 +11,17 @@
 
 namespace Manala\Manalize\Twig;
 
+use Twig\Environment;
+use Twig\Lexer as BaseLexer;
+
 /**
  * Manalize Twig Lexer.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class Lexer extends \Twig_Lexer
+final class Lexer extends BaseLexer
 {
-    public function __construct(\Twig_Environment $env)
+    public function __construct(Environment $env)
     {
         parent::__construct($env, ['tag_comment' => ['[#', '#]'], 'tag_variable' => ['{#', '#}']]);
     }


### PR DESCRIPTION
Not an insane PR, but this should fix Twig deprecations in tests:
![Sélection_396](https://user-images.githubusercontent.com/2103975/54280328-7cf01d80-4597-11e9-8ae7-3082048e2ce9.png)

Recently in Twig, class aliases (`\Twig_Environment`) have been deprecated for class namespaces (`\Twig\Environment`), refs:
  - https://symfony.com/blog/new-in-twig-namespaced-classes
  - https://github.com/twigphp/Twig/pull/2863
  - https://github.com/twigphp/Twig/pull/2869
  - [changelog](https://github.com/twigphp/Twig/blob/2fe2f2d8bba055f78657b81d01ed588fd22d8cd3/CHANGELOG#L23)
