### PR TITLE
Change the way sections are commented in app_local.yml.sample in a less confusing way

### DIFF
--- a/src/Env/Config/Variable/VagrantBoxVersionResolver.php
+++ b/src/Env/Config/Variable/VagrantBoxVersionResolver.php
@@ -11,9 +11,9 @@
 
 namespace Manala\Manalize\Env\Config\Variable;
 
+use function iter\search;
 use Manala\Manalize\Env\Config\Variable\Dependency\Dependency;
 use Manala\Manalize\Env\Config\Variable\Dependency\VersionBounded;
-use function iter\search;
 
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>

--- a/src/Resources/envs/custom/ansible/group_vars/app_local.yml.sample
+++ b/src/Resources/envs/custom/ansible/group_vars/app_local.yml.sample
@@ -1,41 +1,41 @@
 ---
 
-app_local_options:
+#app_local_options:
+#
+#  app:
+#    env_vars:
+#      XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
+#      PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
 
-  #app:
-  #  env_vars:
-  #    XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
-  #    PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
-
-app_local_patterns:
-
-  #######
-  # Apt #
-  #######
-
-  #apt_repositories:
-  #  - blackfire
-
-  ###################
-  # Php - Blackfire #
-  ###################
-
-  #php_blackfire: false
-
-  #php_blackfire_agent_config:
-  #  - server-id:    ...
-  #  - server-token: ...
-
-  #php_blackfire_client_config:
-  #  - client-id:    ...
-  #  - client-token: ...
-
-  #######
-  # Php #
-  #######
-
-  #php_configs:
-  #  - file: app_local.ini
-  #    config:
-  #      # Symfony ide integration, see: http://symfony.com/doc/current/reference/configuration/framework.html#ide
-  #      - xdebug.file_link_format: "'phpstorm://open?file=%f&line=%l&/srv/app/>/Users/manala/workspace/vendor/app/'"
+#app_local_patterns:
+#
+#  #######
+#  # Apt #
+#  #######
+#
+#  apt_repositories:
+#    - blackfire
+#
+#  ###################
+#  # Php - Blackfire #
+#  ###################
+#
+#  php_blackfire: false
+#
+#  php_blackfire_agent_config:
+#    - server-id:    ...
+#    - server-token: ...
+#
+#  php_blackfire_client_config:
+#    - client-id:    ...
+#    - client-token: ...
+#
+#  #######
+#  # Php #
+#  #######
+#
+#  php_configs:
+#    - file: app_local.ini
+#      config:
+#        # Symfony ide integration, see: http://symfony.com/doc/current/reference/configuration/framework.html#ide
+#        - xdebug.file_link_format: "'phpstorm://open?file=%f&line=%l&/srv/app/>/Users/manala/workspace/vendor/app/'"

--- a/src/Resources/envs/symfony/ansible/group_vars/app_local.yml.sample
+++ b/src/Resources/envs/symfony/ansible/group_vars/app_local.yml.sample
@@ -1,41 +1,41 @@
 ---
 
-app_local_options:
+#app_local_options:
+#
+#  app:
+#    env_vars:
+#      XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
+#      PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
 
-  #app:
-  #  env_vars:
-  #    XDEBUG_CONFIG:  remote_host={{ ansible_eth1.ipv4.address|regex_replace('^(.*)\.\d+$', '\1') }}.1 idekey=app
-  #    PHP_IDE_CONFIG: serverName={{ ansible_fqdn }}
-
-app_local_patterns:
-
-  #######
-  # Apt #
-  #######
-
-  #apt_repositories:
-  #  - blackfire
-
-  ###################
-  # Php - Blackfire #
-  ###################
-
-  #php_blackfire: false
-
-  #php_blackfire_agent_config:
-  #  - server-id:    ...
-  #  - server-token: ...
-
-  #php_blackfire_client_config:
-  #  - client-id:    ...
-  #  - client-token: ...
-
-  #######
-  # Php #
-  #######
-
-  #php_configs:
-  #  - file: app_local.ini
-  #    config:
-  #      # Symfony ide integration, see: http://symfony.com/doc/current/reference/configuration/framework.html#ide
-  #      - xdebug.file_link_format: "'phpstorm://open?file=%f&line=%l&/srv/app/>/Users/manala/workspace/vendor/app/'"
+#app_local_patterns:
+#
+#  #######
+#  # Apt #
+#  #######
+#
+#  apt_repositories:
+#    - blackfire
+#
+#  ###################
+#  # Php - Blackfire #
+#  ###################
+#
+#  php_blackfire: false
+#
+#  php_blackfire_agent_config:
+#    - server-id:    ...
+#    - server-token: ...
+#
+#  php_blackfire_client_config:
+#    - client-id:    ...
+#    - client-token: ...
+#
+#  #######
+#  # Php #
+#  #######
+#
+#  php_configs:
+#    - file: app_local.ini
+#      config:
+#        # Symfony ide integration, see: http://symfony.com/doc/current/reference/configuration/framework.html#ide
+#        - xdebug.file_link_format: "'phpstorm://open?file=%f&line=%l&/srv/app/>/Users/manala/workspace/vendor/app/'"

--- a/tests/Handler/SetupTest.php
+++ b/tests/Handler/SetupTest.php
@@ -30,27 +30,26 @@ class SetupTest extends TestCase
 
     public function provideHandleData()
     {
-        return [
+        yield [
+            [],
             [
-                [],
-                [
-                    'Vagrantfile',
-                    'ansible/.manalize.yml',
-                    'ansible/ansible.yml',
-                    'ansible/app.yml',
-                    'ansible/deploy.yml',
-                    'ansible/group_vars/app.yml',
-                    'ansible/group_vars/app_local.yml.sample',
-                    'ansible/group_vars/deploy.yml',
-                    'ansible/group_vars/deploy_staging.yml',
-                    'ansible/group_vars/deploy_production.yml',
-                    'Makefile',
-                ],
+                'Vagrantfile',
+                'ansible/.manalize.yml',
+                'ansible/ansible.yml',
+                'ansible/app.yml',
+                'ansible/deploy.yml',
+                'ansible/group_vars/app.yml',
+                'ansible/group_vars/app_local.yml.sample',
+                'ansible/group_vars/deploy.yml',
+                'ansible/group_vars/deploy_staging.yml',
+                'ansible/group_vars/deploy_production.yml',
+                'Makefile',
             ],
-            [
-                ['dumper_flags' => Dumper::DUMP_METADATA],
-                ['ansible/.manalize.yml'],
-            ],
+        ];
+
+        yield [
+            ['dumper_flags' => Dumper::DUMP_METADATA],
+            ['ansible/.manalize.yml'],
         ];
     }
 


### PR DESCRIPTION
Less chances to uncomment `php_configs` without the `app_local_patterns` by commenting the whole section in a single block.